### PR TITLE
Standardize next dockerfile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   conditions:
     name: Check for cluster conditions
-    uses: bratislava/github-actions/.github/workflows/cluster-deploy-conditions.yml@stable
+    uses: bratislava/github-actions/.github/workflows/cluster-deploy-conditions-inhouse.yml@stable
 
   deploy-dev:
     name: after dev Strapi deploy Next
     if: needs.conditions.outputs.dev == 'true'
     needs: [conditions, deploy-dev-strapi]
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@beta
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@beta
     with:
       directory: next/
       cluster: tkg-innov-dev
@@ -33,7 +33,7 @@ jobs:
     name: dev Strapi
     needs: conditions
     if: needs.conditions.outputs.dev-strapi == 'true'
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@beta
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@beta
     with:
       directory: strapi/
       cluster: tkg-innov-dev
@@ -49,7 +49,7 @@ jobs:
     name: dev Next
     needs: conditions
     if: needs.conditions.outputs.dev-next == 'true'
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@beta
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@beta
     with:
       directory: next/
       cluster: tkg-innov-dev
@@ -65,13 +65,13 @@ jobs:
     name: after staging Strapi deploy Next
     if: needs.conditions.outputs.staging == 'true'
     needs: [conditions, deploy-staging-strapi]
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@stable
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
       cluster: tkg-innov-staging
       url: https://tkg.staging.bratislava.sk
-      flag: --staging
       debug: --debug
+      flag: --staging
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -81,13 +81,13 @@ jobs:
     name: staging Strapi
     needs: conditions
     if: needs.conditions.outputs.staging-strapi == 'true'
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@stable
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: strapi/
       cluster: tkg-innov-staging
       url: https://tkg.staging.bratislava.sk
-      flag: --staging
       debug: --debug
+      flag: --staging
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -97,13 +97,13 @@ jobs:
     name: staging Next
     needs: conditions
     if: needs.conditions.outputs.staging-next == 'true'
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@stable
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
       cluster: tkg-innov-staging
       url: https://tkg.staging.bratislava.sk
-      flag: --staging
       debug: --debug
+      flag: --staging
     secrets:
       service-account: ${{ secrets.STAGING_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -113,7 +113,7 @@ jobs:
     name: after prod Strapi deploy Next
     if: needs.conditions.outputs.prod == 'true'
     needs: [conditions, deploy-prod-strapi]
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@stable
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
       cluster: tkg-innov-prod
@@ -128,12 +128,13 @@ jobs:
     name: prod Strapi
     needs: conditions
     if: needs.conditions.outputs.prod-strapi == 'true'
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@stable
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: strapi/
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}
@@ -143,12 +144,13 @@ jobs:
     name: prod Next
     needs: conditions
     if: needs.conditions.outputs.prod-next == 'true'
-    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli.yml@stable
+    uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
       cluster: tkg-innov-prod
       url: https://tkg.bratislava.sk
       flag: --production
+      debug: --debug
     secrets:
       service-account: ${{ secrets.PROD_STANDALONE_TOKEN }}
       registry-pass: ${{ secrets.HARBOR_REGISTRY_PASSWORD }}

--- a/next/.dockerignore
+++ b/next/.dockerignore
@@ -1,7 +1,10 @@
 .gitignore
+.git/
 .dockerignore
-Dockerfile
+*Dockerfile*
 dist
+node_modules
+npm.debug.log
 .env
 .env.example
 .env.test
@@ -14,14 +17,17 @@ dist
 .env.bratiska-cli-build.dev
 .env.bratiska-cli-build.staging
 .env.bratiska-cli-build.prod
-node_modules
 misc
 .idea
 .nvmrc
 .tmp/
 .cache/
-.git/
 build/
 data/
-.next
-
+.next/
+# kustomize files
+kubernetes/
+# bratiska-cli manifest files
+manifest-*.y?ml
+# markdown files
+**/*.md

--- a/next/Dockerfile
+++ b/next/Dockerfile
@@ -1,64 +1,46 @@
-FROM node:16 as build
+FROM node:16-alpine AS base
 
-ENV PORT 3000
+FROM base AS build-base
+WORKDIR /build
+COPY ./package.json ./yarn.lock ./
 
-WORKDIR /root/app
+FROM build-base AS install-prod
+ENV YARN_CACHE_FOLDER=/build/.cache/yarn
+RUN --mount=type=cache,target=/build/.cache/yarn \
+    yarn config set network-timeout 600000 -g \
+ && yarn install --production --frozen-lockfile
 
-COPY package*.json /root/app
-COPY yarn.lock /root/app
-
-RUN yarn config set network-timeout 600000 -g
-RUN yarn install
-
+FROM install-prod AS build
 COPY . ./
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN --mount=type=cache,target=/build/.cache/yarn \
+    yarn install --development --frozen-lockfile \
+ && yarn build
 
-RUN yarn build
-
-
-FROM node:16 as dev
-
-RUN mkdir -p /root/app
-ENV PORT 3000
-
-WORKDIR /root/app
-
-ARG NODE_ENV=development
-ENV NODE_ENV=${NODE_ENV}
-
-COPY package*.json /root/app
-COPY yarn.lock /root/app
-
-RUN yarn config set network-timeout 600000 -g
-RUN yarn install
-
-COPY . ./
-
-RUN yarn build
-
+FROM base AS app-base
+RUN apk add --no-cache tini
+RUN mkdir -p /home/node/app \
+ && chown node:node /home/node/app
+USER node
+WORKDIR /home/node/app
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production
 EXPOSE 3000
+ARG GIT_COMMIT="undefined"
+ENV GIT_COMMIT=$GIT_COMMIT
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.source="https://github.com/bratislava/gmb.sk" \
+      org.opencontainers.image.licenses="EUPL-1.2"
+ENTRYPOINT [ "/sbin/tini", "--" ]
+
+FROM app-base AS dev
+ENV NODE_ENV=development
+COPY --chown=node:node --from=build /build/node_modules ./node_modules
 CMD [ "yarn", "develop" ]
 
-FROM node:16-alpine as prod
-
-USER node
-ENV PORT 3000
-
-RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
-
-WORKDIR /home/node/app
-
-ARG NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
-
-COPY --chown=node:node package*.json ./
-COPY --chown=node:node yarn.lock ./
-
-RUN yarn config set network-timeout 600000 -g
-RUN yarn install --production
-
-COPY . ./
-
-COPY --chown=node:node --from=build /root/app/.next ./.next
-
-EXPOSE 3000
-CMD [ "yarn", "start" ]
+FROM app-base AS prod
+COPY --chown=node:node .env.*.local ./
+COPY --chown=node:node --from=build /build/.next/standalone ./
+COPY --chown=node:node --from=build /build/public ./public
+COPY --chown=node:node --from=build /build/.next/static ./.next/static
+CMD [ "node", "server.js" ]

--- a/next/kubernetes/base/ingress.yml
+++ b/next/kubernetes/base/ingress.yml
@@ -12,11 +12,11 @@ metadata:
 spec:
   tls:
     - hosts:
-        - ${HOSTNAME}
-        - www.${HOSTNAME}
+        - ${BRATISKA_HOSTNAME}
+        - www.${BRATISKA_HOSTNAME}
       secretName: ${BUILD_REPOSITORY_NAME}-tls
   rules:
-    - host: ${HOSTNAME}
+    - host: ${BRATISKA_HOSTNAME}
       http:
         paths:
           - path: /
@@ -26,7 +26,7 @@ spec:
                 name: ${BUILD_REPOSITORY_NAME}-app
                 port:
                   number: 80
-    - host: www.${HOSTNAME}
+    - host: www.${BRATISKA_HOSTNAME}
       http:
         paths:
           - path: /

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -21,6 +21,8 @@ const nextConfig = {
   serverRuntimeConfig: {
     strapiUrl: process.env.STRAPI_URL,
   },
+  output: 'standalone',
+
   async rewrites() {
     return {
       beforeFiles: [
@@ -372,7 +374,6 @@ const nextConfig = {
         destination: '/detail/goticka-tabulova-malba-a-plastika',
         locale: false,
         permanent: true,
-        locale: false,
       },
       {
         source: '/sk/exhibition/detail/131',

--- a/strapi/Dockerfile
+++ b/strapi/Dockerfile
@@ -1,51 +1,68 @@
-# development
-FROM node:16 AS dev
+FROM node:16-alpine AS base
 
-RUN apt-get update && apt-get install -y git \
-    vim \
-    libvips-dev
+FROM base AS build-base
+RUN apk update \
+ && apk add --no-cache build-base \
+                       gcc \
+                       autoconf \
+                       automake \
+                       zlib-dev \
+                       libpng-dev \
+                       vips-dev
+WORKDIR /build
+COPY ./package.json ./yarn.lock ./
+# Uncomment if you need any to apply any patches
+# COPY patches ./patches
+# copy any installation files for Strapi plugins you want to build. For example:
+# COPY src/plugins/<package-name>/package.json src/plugins/<package-name>/yarn.lock ./src/plugins/<package-name>
+# Or leave empty (do not add anyting) if you don't have any custom plugins (most likely ./plugins directory)
 
-ARG NODE_ENV=development
-ENV NODE_ENV=${NODE_ENV}
+FROM build-base AS install-prod
+ENV YARN_CACHE_FOLDER=/build/.cache/yarn
+RUN --mount=type=cache,target=/build/.cache/yarn \
+    yarn config set network-timeout 600000 -g \
+ && yarn install --production
 
-WORKDIR /home/node/app
-COPY package*.json ./
-COPY yarn.lock ./
-COPY patches ./patches
+FROM install-prod AS build
+WORKDIR /build/app
+COPY ./ .
+RUN --mount=type=cache,target=/build/.cache/yarn \
+    yarn install --development \
+ && yarn build
 
-RUN yarn install
-COPY . ./
-
-RUN yarn build
-
-EXPOSE 1337
-CMD ["yarn", "develop"]
-
-# production
-FROM node:16 AS prod
-
-RUN apt-get update && apt-get install -y git \
-    libvips-dev
-
+FROM base AS app-base
+RUN apk add --no-cache vips-dev \
+                       tini
+RUN mkdir -p /home/node/app \
+ && chown node:node /home/node/app
 USER node
-
-RUN mkdir -p /home/node/app && chown -R node:node /home/node/app
 WORKDIR /home/node/app
-
-ARG NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
-# ENV PATH /home/node/node_modules/.bin:$PATH
-
-COPY --chown=node:node package*.json ./
-COPY --chown=node:node yarn.lock ./
-COPY --chown=node:node patches ./patches
-
-RUN yarn config set network-timeout 600000 -g
-RUN yarn install --production
-
-COPY . ./
-
-RUN yarn build
-
+# Adds strapi cli to the PATH
+ENV PATH=/home/node/app/node_modules/.bin:$PATH
+ENV NODE_ENV=production
 EXPOSE 1337
-CMD ["yarn", "start"]
+ARG GIT_COMMIT="undefined"
+ENV GIT_COMMIT=$GIT_COMMIT
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}" \
+      org.opencontainers.image.source="https://github.com/bratislava/gmb.sk" \
+      org.opencontainers.image.licenses="EUPL-1.2"
+ENTRYPOINT [ "/sbin/tini", "--" ]
+
+FROM app-base AS dev
+ENV NODE_ENV=development
+COPY --chown=node:node --from=build /build/node_modules ./node_modules
+CMD [ "yarn", "develop" ]
+
+FROM app-base AS prod
+COPY --chown=node:node --from=build /build/app/favicon.ico /build/package.json /build/yarn.lock /build/app/tsconfig.json ./
+COPY --chown=node:node --from=install-prod /build/node_modules ./node_modules
+COPY --chown=node:node --from=build /build/app/config ./config
+COPY --chown=node:node --from=build /build/app/public ./public
+COPY --chown=node:node --from=build /build/app/dist ./dist
+# COPY to final image any built Strapi plugins. In this stage you will *ONLY* need
+# - plugins/<name>/yarn.lock
+# - plugins/<name>/package.json
+# - plugins/<name>/dist/
+# - plugins/<name>/*.js
+# Or leave empty (do not add anyting) if you don't have any custom plugins (most likely ./plugins directory)
+CMD [ "strapi", "start" ]

--- a/strapi/kubernetes/base/ingress.yml
+++ b/strapi/kubernetes/base/ingress.yml
@@ -12,11 +12,11 @@ metadata:
 spec:
   tls:
     - hosts:
-        - ${HOSTNAME}
+        - ${BRATISKA_HOSTNAME}
         - ${BUILD_REPOSITORY_NAME}-meilisearch.${DEPLOYMENT_ENV}bratislava.sk
       secretName: ${BUILD_REPOSITORY_NAME}-tls
   rules:
-    - host: ${HOSTNAME}
+    - host: ${BRATISKA_HOSTNAME}
       http:
         paths:
           - path: /


### PR DESCRIPTION
- use standardized Dockerfile for Next
- next config must contain `output: "standalone"`
- update .dockerignore
- bratiska-cli old version were using $HOSTNAME to build ingress URLs. This env variable is reserved also for names of systems running it. Therefore, there was conflict between env names and wrong variable value were inserted into ingress URL