### PR TITLE
#282 Unify robots file

### DIFF
--- a/next/.env.bratiska-cli-build.dev
+++ b/next/.env.bratiska-cli-build.dev
@@ -1,6 +1,7 @@
 STRAPI_URL=https://city-gallery-strapi.dev.bratislava.sk
 NEXT_PUBLIC_NEXT_URL=https://city-gallery-next.dev.bratislava.sk
-NEXT_PUBLIC_IS_PROD=false
+
+NEXT_PUBLIC_DEPLOYMENT=dev
 
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiYnJhdGlzbGF2YTAxIiwiYSI6ImNreWp4d3RmbDJxdHcyb24wcTRzODV1Z2oifQ.ted1x1pbp8w3jZG0MygBUw
 

--- a/next/.env.bratiska-cli-build.prod
+++ b/next/.env.bratiska-cli-build.prod
@@ -1,6 +1,7 @@
 STRAPI_URL=https://city-gallery-strapi.bratislava.sk
 NEXT_PUBLIC_NEXT_URL=https://www.gmb.sk
-NEXT_PUBLIC_IS_PROD=true
+
+NEXT_PUBLIC_DEPLOYMENT=prod
 
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiYnJhdGlzbGF2YTAxIiwiYSI6ImNreWp4d3RmbDJxdHcyb24wcTRzODV1Z2oifQ.ted1x1pbp8w3jZG0MygBUw
 

--- a/next/.env.bratiska-cli-build.staging
+++ b/next/.env.bratiska-cli-build.staging
@@ -1,6 +1,7 @@
 STRAPI_URL=https://city-gallery-strapi.staging.bratislava.sk
 NEXT_PUBLIC_NEXT_URL=https://city-gallery-next.staging.bratislava.sk
-NEXT_PUBLIC_IS_PROD=false
+
+NEXT_PUBLIC_DEPLOYMENT=staging
 
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiYnJhdGlzbGF2YTAxIiwiYSI6ImNreWp4d3RmbDJxdHcyb24wcTRzODV1Z2oifQ.ted1x1pbp8w3jZG0MygBUw
 

--- a/next/next.config.js
+++ b/next/next.config.js
@@ -82,6 +82,11 @@ const nextConfig = {
   async redirects() {
     return [
       {
+        source: '/robots.txt',
+        destination: '/api/robots',
+        permanent: true,
+      },
+      {
         source: '/sk/home',
         destination: '/',
         permanent: true,

--- a/next/pages/api/robots.ts
+++ b/next/pages/api/robots.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+// Copied from bratislava.sk https://github.com/bratislava/bratislava.sk/blob/master/next/pages/api/robots.ts
+const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
+  if (process.env.NEXT_PUBLIC_DEPLOYMENT === 'prod') {
+    /* In production, disallow to crawl /api endpoints */
+    return res.send(
+      `
+        User-agent: *
+        Disallow: /api/
+      `,
+    )
+  }
+
+  /* If not in production, disallow to crawl the website completely */
+  return res.send(
+    `
+      User-Agent: *
+      Disallow: /
+    `,
+  )
+}
+
+export default handler

--- a/next/utils/isProd.ts
+++ b/next/utils/isProd.ts
@@ -1,3 +1,3 @@
 export const isProd = () => {
-  return process.env.NEXT_PUBLIC_IS_PROD === 'true'
+  return process.env.NEXT_PUBLIC_DEPLOYMENT === 'prod'
 }


### PR DESCRIPTION
### Description

Implement robots file according to OLO/bratislava.sk

### Testing

Visit /robots.txt, you should be redirected to /api/robots and see robots file according to `NEXT_PUBLIC_DEPLOYMENT` variable.
For all non-prod:
```
      User-Agent: *
      Disallow: /
```
For prod:
```
        User-agent: *
        Disallow: /api/
```

### Notes
I changed also env vars to have the same approach in projects from `NEXT_PUBLIC_IS_PROD` to `NEXT_PUBLIC_DEPLOYMENT`. 