### PR TITLE
Replace `yarn` with `npm` in packages.json scripts and readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We intend to make many more of our projects open-source by the end of 2022 - sta
 
 Follow user guide in folders `/strapi` and `/next`.
 
-You need `node` and `yarn` installed locally.
+You need `node` and `npm` installed locally.
 
 If you want to start a postgres database and meilisearch instance with correct credentials, simply run:
 
@@ -42,25 +42,6 @@ curl --request GET \
 ```
 
 Then use "Default Admin API Key" for strapi in `strapi/.env.local` as `MEILISEARCH_ADMIN_API_KEY` and "Default Search API Key" in `next/.env.local` file as `NEXT_PUBLIC_MEILISEARCH_SEARCH_API_KEY`.
-
-## Deployment
-
-### Manual
-
-You can use our `bratiska-cli`, which takes care of deploying the app.
-
-1. First, install the utility:
-
-   ```bash
-   yarn global add bratislava/bratiska-cli
-   ```
-
-2. then go to folder of `/strapi` or `/next` and run just this command:
-   ```bash
-   bartiska-cli deploy
-   ```
-
-That`s all, everything should run automatically and if not you will be notified. You can also check [user guide of bratiska-cli](https://github.com/bratislava/bratiska-cli/blob/master/README.md).
 
 ## Stay in touch
 

--- a/next/README.md
+++ b/next/README.md
@@ -3,14 +3,13 @@
 Install dependencies:
 
 ```bash
-yarn
+npm install
 ```
 
 To start the frontend app, simply run:
 
 ```bash
-yarn dev
-# the same as yarn develop
+npm run dev
 ```
 
 For CMS setup see `strapi` directory. You can also run the project against staging or production strapi (useful when developing and debugging) - provided that you're not working on Strapi model changes.
@@ -24,7 +23,7 @@ When you change something in Strapi Content type builder, and/or if you change G
 To generate new types run:
 
 ```
-yarn gen
+npm run gen
 ```
 
 For more information, refer to [the documentation](/docs/libs/Strapi-SDK.md).
@@ -62,8 +61,8 @@ async rewrites() {
 
 ## Static Site Generation
 
-If you want to test static site generation locally, you need to run `yarn build` and `yarn start`. This commands run by default with the prod env variable, so in order to have the local env variable for strapi, you need to create `.env.local` with `STRAPI_URL=localhost:1337` to override the prod values. This file is ignored by git, because it often contains sensitive secrets
+If you want to test static site generation locally, you need to run `npm run build` and `npm run start`. This commands run by default with the prod env variable, so in order to have the local env variable for strapi, you need to create `.env.local` with `STRAPI_URL=localhost:1337` to override the prod values. This file is ignored by git, because it often contains sensitive secrets
 
-## Fluid resposive design
+## Fluid responsive design
 
 If you need to change some font sizes or spacing, check the `styles/globals.css` and `tailwing.config.js` files how are all sizes set up.

--- a/next/package.json
+++ b/next/package.json
@@ -10,11 +10,11 @@
     "start": "next start",
     "gen": "graphql-codegen && prettier --write src/services/graphql/index.ts",
     "lint": "eslint src",
-    "lint:quiet": "yarn lint --quiet",
-    "lint:fix": "yarn lint --fix",
+    "lint:quiet": "npm run lint --quiet",
+    "lint:fix": "npm run lint --fix",
     "prettier": "prettier --write .",
     "parse-translations": "i18next",
-    "update-i18next": "npm install next-i18next@latest react-i18next@latest i18next@latest --save-exact && yarn add eslint-plugin-i18next@latest i18next-parser@latest --save-dev --save-exact"
+    "update-i18next": "npm install next-i18next@latest react-i18next@latest i18next@latest --save-exact && npm install eslint-plugin-i18next@latest i18next-parser@latest --save-dev --save-exact"
   },
   "dependencies": {
     "@react-stately/toggle": "^3.5.1",

--- a/strapi/README.md
+++ b/strapi/README.md
@@ -5,7 +5,7 @@
 Before you start, install all dependencies and create `.env.local` file which is .gitignored and used for local dev.
 
 ```
-yarn
+npm install
 cp .env.example .env.local
 ```
 
@@ -16,7 +16,7 @@ You need postgres running locally (with correct credentials & database available
 Build your admin panel. [Learn more](https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-build)
 
 ```
-yarn build
+npm run build
 ```
 
 ## Start development server
@@ -24,7 +24,7 @@ yarn build
 Start your Strapi application with autoReload enabled. [Learn more](https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-develop)
 
 ```
-yarn dev
+npm run dev
 ```
 
 ## Start server
@@ -32,7 +32,7 @@ yarn dev
 Start your Strapi application with autoReload disabled (not needed for development). [Learn more](https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-start)
 
 ```
-yarn start
+npm run start
 ```
 
 ## Set permissions


### PR DESCRIPTION
Replace `yarn` with `npm` where forgotten.