### PR TITLE
Revert to not specifying basePath

### DIFF
--- a/next/next-i18next.config.js
+++ b/next/next-i18next.config.js
@@ -1,5 +1,5 @@
-const path = require('path')
-
+// This config is used by next-i18next. The `i18n` "subconfig" should be also imported and used in next.config.js.
+// Docs: https://github.com/i18next/next-i18next?tab=readme-ov-file#3-project-setup
 /**
  * @type {import('next-i18next').UserConfig}
  */

--- a/next/tsconfig.json
+++ b/next/tsconfig.json
@@ -19,7 +19,9 @@
         "name": "next"
       }
     ],
-    "baseUrl": "./",
+    // TODO - solve a problem with build when uncommented
+    // baseUrl should be specified when paths is used. It wasn't. But when we tried to specify it, it caused a problem with i18n from useTranslation() not having .language prop.
+    // "baseUrl": "./",
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
Usually, basePath should be specified when path aliases are used. But when we specified it in the last commit, it causes problem with build (i18n was missin .language property).
It should be revisited, basePath should be specified and build problems should be solved.