### PR TITLE
#264 Add Menu content type

### DIFF
--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -269,6 +269,15 @@ export type ComponentBlocksLinksInput = {
   title?: InputMaybe<Scalars['String']>;
 };
 
+export type ComponentBlocksMenuLinkItem = {
+  __typename?: 'ComponentBlocksMenuLinkItem';
+  hasButtonStyle?: Maybe<Scalars['Boolean']>;
+  id: Scalars['ID'];
+  mainPage?: Maybe<MainPageEntityResponse>;
+  title: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
+};
+
 export type ComponentBlocksPalace = {
   __typename?: 'ComponentBlocksPalace';
   address?: Maybe<Scalars['String']>;
@@ -1023,7 +1032,7 @@ export type GeneralRelationResponseCollection = {
   data: Array<GeneralEntity>;
 };
 
-export type GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage;
+export type GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage;
 
 export type GetInvolvedPage = {
   __typename?: 'GetInvolvedPage';
@@ -3034,6 +3043,8 @@ export type HighlightFragment = { __typename?: 'ComponentBlocksContentPageItem',
 
 export type PartnerFragment = { __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null };
 
+export type MenuLinkItemFragment = { __typename?: 'ComponentBlocksMenuLinkItem', id: string, title: string, url?: string | null, hasButtonStyle?: boolean | null, mainPage?: { __typename?: 'MainPageEntityResponse', data?: { __typename?: 'MainPageEntity', id?: string | null, attributes?: { __typename?: 'MainPage', title: string, slug: string, sections?: Array<{ __typename: 'ComponentSectionsHighlights', id: string, highlights?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsMapSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsletterSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsOpeningHoursSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsPageSection', id: string, title?: string | null, submenuTitle?: string | null, layout?: Enum_Componentsectionspagesection_Layout | null, contentPages?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsPartners', id: string, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsTicketsSection', id: string, title?: string | null, submenuTitle?: string | null, text?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'MainPageRelationResponseCollection', data: Array<{ __typename?: 'MainPageEntity', attributes?: { __typename?: 'MainPage', slug: string, locale?: string | null } | null }> } | null } | null } | null } | null };
+
 export type DownloadItemFragment = { __typename?: 'ComponentBlocksFileItem', id: string, title?: string | null, file: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', name: string, caption?: string | null, alternativeText?: string | null, ext?: string | null, size: number, url: string } | null } | null } };
 
 export type PalaceDetailsFragment = { __typename?: 'ComponentBlocksPalace', title?: string | null, address?: string | null, zip?: string | null, city?: string | null, phone?: string | null };
@@ -3286,27 +3297,6 @@ export const TicketEntityFragmentDoc = gql`
   }
 }
     `;
-export const NewsItemEntityFragmentDoc = gql`
-    fragment NewsItemEntity on ContentPageEntity {
-  id
-  attributes {
-    title
-    subtitle
-    addedAt
-    useDatetimeAsSubtitle
-    slug
-    color
-    inheritColorFromParent
-    parentPage {
-      data {
-        attributes {
-          color
-        }
-      }
-    }
-  }
-}
-    `;
 export const ImageEntityFragmentDoc = gql`
     fragment ImageEntity on UploadFileEntity {
   attributes {
@@ -3326,134 +3316,6 @@ export const DatetimeFragmentDoc = gql`
   showRemainingTime
 }
     `;
-export const TagEntityFragmentDoc = gql`
-    fragment TagEntity on TagEntity {
-  attributes {
-    title
-    slug
-  }
-}
-    `;
-export const SectionItemEntityFragmentDoc = gql`
-    fragment SectionItemEntity on ContentPageEntity {
-  ...NewsItemEntity
-  attributes {
-    perex
-    coverMedia {
-      data {
-        ...ImageEntity
-      }
-    }
-    ...Datetime
-    tags {
-      data {
-        ...TagEntity
-      }
-    }
-  }
-}
-    ${NewsItemEntityFragmentDoc}
-${ImageEntityFragmentDoc}
-${DatetimeFragmentDoc}
-${TagEntityFragmentDoc}`;
-export const PageSectionFragmentDoc = gql`
-    fragment PageSection on ComponentSectionsPageSection {
-  id
-  title
-  submenuTitle
-  layout
-  contentPages {
-    contentPage {
-      data {
-        ...SectionItemEntity
-      }
-    }
-  }
-}
-    ${SectionItemEntityFragmentDoc}`;
-export const NewsSectionFragmentDoc = gql`
-    fragment NewsSection on ComponentSectionsNewsSection {
-  id
-  title
-  submenuTitle
-}
-    `;
-export const OpeningHoursSectionFragmentDoc = gql`
-    fragment OpeningHoursSection on ComponentSectionsOpeningHoursSection {
-  id
-  submenuTitle
-}
-    `;
-export const NewsletterSectionFragmentDoc = gql`
-    fragment NewsletterSection on ComponentSectionsNewsletterSection {
-  id
-  submenuTitle
-}
-    `;
-export const TicketsSectionFragmentDoc = gql`
-    fragment TicketsSection on ComponentSectionsTicketsSection {
-  id
-  title
-  submenuTitle
-  text
-}
-    `;
-export const MapSectionFragmentDoc = gql`
-    fragment MapSection on ComponentSectionsMapSection {
-  id
-  title
-  submenuTitle
-}
-    `;
-export const RichtextSectionFragmentDoc = gql`
-    fragment RichtextSection on ComponentSectionsRichtextSection {
-  id
-  submenuTitle
-  content
-}
-    `;
-export const SectionsFragmentDoc = gql`
-    fragment Sections on VisitUsPageSectionsDynamicZone {
-  ... on Error {
-    code
-    message
-  }
-  ... on ComponentSectionsPageSection {
-    __typename
-    ...PageSection
-  }
-  ... on ComponentSectionsNewsSection {
-    __typename
-    ...NewsSection
-  }
-  ... on ComponentSectionsOpeningHoursSection {
-    __typename
-    ...OpeningHoursSection
-  }
-  ... on ComponentSectionsNewsletterSection {
-    __typename
-    ...NewsletterSection
-  }
-  ... on ComponentSectionsTicketsSection {
-    __typename
-    ...TicketsSection
-  }
-  ... on ComponentSectionsMapSection {
-    __typename
-    ...MapSection
-  }
-  ... on ComponentSectionsRichtextSection {
-    __typename
-    ...RichtextSection
-  }
-}
-    ${PageSectionFragmentDoc}
-${NewsSectionFragmentDoc}
-${OpeningHoursSectionFragmentDoc}
-${NewsletterSectionFragmentDoc}
-${TicketsSectionFragmentDoc}
-${MapSectionFragmentDoc}
-${RichtextSectionFragmentDoc}`;
 export const PlaceEntityFragmentDoc = gql`
     fragment PlaceEntity on PlaceEntity {
   attributes {
@@ -3488,40 +3350,6 @@ export const PositionsFragmentDoc = gql`
   }
 }
     ${PositionFragmentDoc}`;
-export const HighlightsItemEntityFragmentDoc = gql`
-    fragment HighlightsItemEntity on ContentPageEntity {
-  ...SectionItemEntity
-  attributes {
-    titleToShow
-    ...ContentPagePlace
-    ...Positions
-    sellTickets
-    purchaseId
-    override {
-      highlightContent
-    }
-  }
-}
-    ${SectionItemEntityFragmentDoc}
-${ContentPagePlaceFragmentDoc}
-${PositionsFragmentDoc}`;
-export const HighlightFragmentDoc = gql`
-    fragment Highlight on ComponentBlocksContentPageItem {
-  contentPage {
-    data {
-      ...HighlightsItemEntity
-    }
-  }
-}
-    ${HighlightsItemEntityFragmentDoc}`;
-export const HighlightsSectionFragmentDoc = gql`
-    fragment HighlightsSection on ComponentSectionsHighlights {
-  id
-  highlights {
-    ...Highlight
-  }
-}
-    ${HighlightFragmentDoc}`;
 export const PartnerEntityFragmentDoc = gql`
     fragment PartnerEntity on PartnerEntity {
   id
@@ -3536,74 +3364,6 @@ export const PartnerEntityFragmentDoc = gql`
   }
 }
     ${ImageEntityFragmentDoc}`;
-export const PartnerFragmentDoc = gql`
-    fragment Partner on ComponentBlocksPartnerItem {
-  partner {
-    data {
-      ...PartnerEntity
-    }
-  }
-}
-    ${PartnerEntityFragmentDoc}`;
-export const PartnersSectionFragmentDoc = gql`
-    fragment PartnersSection on ComponentSectionsPartners {
-  id
-  partners {
-    ...Partner
-  }
-}
-    ${PartnerFragmentDoc}`;
-export const MainPageSectionsFragmentDoc = gql`
-    fragment MainPageSections on MainPageSectionsDynamicZone {
-  ...Sections
-  ... on ComponentSectionsHighlights {
-    __typename
-    ...HighlightsSection
-  }
-  ... on ComponentSectionsPartners {
-    __typename
-    ...PartnersSection
-  }
-}
-    ${SectionsFragmentDoc}
-${HighlightsSectionFragmentDoc}
-${PartnersSectionFragmentDoc}`;
-export const SeoFragmentDoc = gql`
-    fragment Seo on ComponentBlocksSeo {
-  metaTitle
-  metaDescription
-  keywords
-  metaImage {
-    data {
-      ...ImageEntity
-    }
-  }
-}
-    ${ImageEntityFragmentDoc}`;
-export const MainPageEntityFragmentDoc = gql`
-    fragment MainPageEntity on MainPageEntity {
-  id
-  attributes {
-    title
-    slug
-    sections {
-      ...MainPageSections
-    }
-    seo {
-      ...Seo
-    }
-    localizations {
-      data {
-        attributes {
-          slug
-          locale
-        }
-      }
-    }
-  }
-}
-    ${MainPageSectionsFragmentDoc}
-${SeoFragmentDoc}`;
 export const PartnersFragmentDoc = gql`
     fragment Partners on ContentPage {
   partners(pagination: {limit: 100}) {
@@ -3615,6 +3375,13 @@ export const PartnersFragmentDoc = gql`
   }
 }
     ${PartnerEntityFragmentDoc}`;
+export const RichtextSectionFragmentDoc = gql`
+    fragment RichtextSection on ComponentSectionsRichtextSection {
+  id
+  submenuTitle
+  content
+}
+    `;
 export const VideoSectionFragmentDoc = gql`
     fragment VideoSection on ComponentSectionsVideoSection {
   id
@@ -3749,6 +3516,69 @@ export const DownloadSectionFragmentDoc = gql`
   }
 }
     ${DownloadItemFragmentDoc}`;
+export const NewsItemEntityFragmentDoc = gql`
+    fragment NewsItemEntity on ContentPageEntity {
+  id
+  attributes {
+    title
+    subtitle
+    addedAt
+    useDatetimeAsSubtitle
+    slug
+    color
+    inheritColorFromParent
+    parentPage {
+      data {
+        attributes {
+          color
+        }
+      }
+    }
+  }
+}
+    `;
+export const TagEntityFragmentDoc = gql`
+    fragment TagEntity on TagEntity {
+  attributes {
+    title
+    slug
+  }
+}
+    `;
+export const SectionItemEntityFragmentDoc = gql`
+    fragment SectionItemEntity on ContentPageEntity {
+  ...NewsItemEntity
+  attributes {
+    perex
+    coverMedia {
+      data {
+        ...ImageEntity
+      }
+    }
+    ...Datetime
+    tags {
+      data {
+        ...TagEntity
+      }
+    }
+  }
+}
+    ${NewsItemEntityFragmentDoc}
+${ImageEntityFragmentDoc}
+${DatetimeFragmentDoc}
+${TagEntityFragmentDoc}`;
+export const SeoFragmentDoc = gql`
+    fragment Seo on ComponentBlocksSeo {
+  metaTitle
+  metaDescription
+  keywords
+  metaImage {
+    data {
+      ...ImageEntity
+    }
+  }
+}
+    ${ImageEntityFragmentDoc}`;
 export const ContentPageEntityFragmentDoc = gql`
     fragment ContentPageEntity on ContentPageEntity {
   id
@@ -3835,6 +3665,200 @@ export const CommonSearchPageEntityFragmentDoc = gql`
   }
 }
     `;
+export const PageSectionFragmentDoc = gql`
+    fragment PageSection on ComponentSectionsPageSection {
+  id
+  title
+  submenuTitle
+  layout
+  contentPages {
+    contentPage {
+      data {
+        ...SectionItemEntity
+      }
+    }
+  }
+}
+    ${SectionItemEntityFragmentDoc}`;
+export const NewsSectionFragmentDoc = gql`
+    fragment NewsSection on ComponentSectionsNewsSection {
+  id
+  title
+  submenuTitle
+}
+    `;
+export const OpeningHoursSectionFragmentDoc = gql`
+    fragment OpeningHoursSection on ComponentSectionsOpeningHoursSection {
+  id
+  submenuTitle
+}
+    `;
+export const NewsletterSectionFragmentDoc = gql`
+    fragment NewsletterSection on ComponentSectionsNewsletterSection {
+  id
+  submenuTitle
+}
+    `;
+export const TicketsSectionFragmentDoc = gql`
+    fragment TicketsSection on ComponentSectionsTicketsSection {
+  id
+  title
+  submenuTitle
+  text
+}
+    `;
+export const MapSectionFragmentDoc = gql`
+    fragment MapSection on ComponentSectionsMapSection {
+  id
+  title
+  submenuTitle
+}
+    `;
+export const SectionsFragmentDoc = gql`
+    fragment Sections on VisitUsPageSectionsDynamicZone {
+  ... on Error {
+    code
+    message
+  }
+  ... on ComponentSectionsPageSection {
+    __typename
+    ...PageSection
+  }
+  ... on ComponentSectionsNewsSection {
+    __typename
+    ...NewsSection
+  }
+  ... on ComponentSectionsOpeningHoursSection {
+    __typename
+    ...OpeningHoursSection
+  }
+  ... on ComponentSectionsNewsletterSection {
+    __typename
+    ...NewsletterSection
+  }
+  ... on ComponentSectionsTicketsSection {
+    __typename
+    ...TicketsSection
+  }
+  ... on ComponentSectionsMapSection {
+    __typename
+    ...MapSection
+  }
+  ... on ComponentSectionsRichtextSection {
+    __typename
+    ...RichtextSection
+  }
+}
+    ${PageSectionFragmentDoc}
+${NewsSectionFragmentDoc}
+${OpeningHoursSectionFragmentDoc}
+${NewsletterSectionFragmentDoc}
+${TicketsSectionFragmentDoc}
+${MapSectionFragmentDoc}
+${RichtextSectionFragmentDoc}`;
+export const HighlightsItemEntityFragmentDoc = gql`
+    fragment HighlightsItemEntity on ContentPageEntity {
+  ...SectionItemEntity
+  attributes {
+    titleToShow
+    ...ContentPagePlace
+    ...Positions
+    sellTickets
+    purchaseId
+    override {
+      highlightContent
+    }
+  }
+}
+    ${SectionItemEntityFragmentDoc}
+${ContentPagePlaceFragmentDoc}
+${PositionsFragmentDoc}`;
+export const HighlightFragmentDoc = gql`
+    fragment Highlight on ComponentBlocksContentPageItem {
+  contentPage {
+    data {
+      ...HighlightsItemEntity
+    }
+  }
+}
+    ${HighlightsItemEntityFragmentDoc}`;
+export const HighlightsSectionFragmentDoc = gql`
+    fragment HighlightsSection on ComponentSectionsHighlights {
+  id
+  highlights {
+    ...Highlight
+  }
+}
+    ${HighlightFragmentDoc}`;
+export const PartnerFragmentDoc = gql`
+    fragment Partner on ComponentBlocksPartnerItem {
+  partner {
+    data {
+      ...PartnerEntity
+    }
+  }
+}
+    ${PartnerEntityFragmentDoc}`;
+export const PartnersSectionFragmentDoc = gql`
+    fragment PartnersSection on ComponentSectionsPartners {
+  id
+  partners {
+    ...Partner
+  }
+}
+    ${PartnerFragmentDoc}`;
+export const MainPageSectionsFragmentDoc = gql`
+    fragment MainPageSections on MainPageSectionsDynamicZone {
+  ...Sections
+  ... on ComponentSectionsHighlights {
+    __typename
+    ...HighlightsSection
+  }
+  ... on ComponentSectionsPartners {
+    __typename
+    ...PartnersSection
+  }
+}
+    ${SectionsFragmentDoc}
+${HighlightsSectionFragmentDoc}
+${PartnersSectionFragmentDoc}`;
+export const MainPageEntityFragmentDoc = gql`
+    fragment MainPageEntity on MainPageEntity {
+  id
+  attributes {
+    title
+    slug
+    sections {
+      ...MainPageSections
+    }
+    seo {
+      ...Seo
+    }
+    localizations {
+      data {
+        attributes {
+          slug
+          locale
+        }
+      }
+    }
+  }
+}
+    ${MainPageSectionsFragmentDoc}
+${SeoFragmentDoc}`;
+export const MenuLinkItemFragmentDoc = gql`
+    fragment MenuLinkItem on ComponentBlocksMenuLinkItem {
+  id
+  title
+  url
+  mainPage {
+    data {
+      ...MainPageEntity
+    }
+  }
+  hasButtonStyle
+}
+    ${MainPageEntityFragmentDoc}`;
 export const PalaceDetailsFragmentDoc = gql`
     fragment PalaceDetails on ComponentBlocksPalace {
   title

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -269,6 +269,33 @@ export type ComponentBlocksLinksInput = {
   title?: InputMaybe<Scalars['String']>;
 };
 
+export type ComponentBlocksMenuLinkItem = {
+  __typename?: 'ComponentBlocksMenuLinkItem';
+  hasButtonStyle?: Maybe<Scalars['Boolean']>;
+  id: Scalars['ID'];
+  mainPage?: Maybe<MainPageEntityResponse>;
+  title: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
+};
+
+export type ComponentBlocksMenuLinkItemFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>>>;
+  hasButtonStyle?: InputMaybe<BooleanFilterInput>;
+  mainPage?: InputMaybe<MainPageFiltersInput>;
+  not?: InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>;
+  or?: InputMaybe<Array<InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>>>;
+  title?: InputMaybe<StringFilterInput>;
+  url?: InputMaybe<StringFilterInput>;
+};
+
+export type ComponentBlocksMenuLinkItemInput = {
+  hasButtonStyle?: InputMaybe<Scalars['Boolean']>;
+  id?: InputMaybe<Scalars['ID']>;
+  mainPage?: InputMaybe<Scalars['ID']>;
+  title?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars['String']>;
+};
+
 export type ComponentBlocksPalace = {
   __typename?: 'ComponentBlocksPalace';
   address?: Maybe<Scalars['String']>;
@@ -1029,7 +1056,7 @@ export type GeneralRelationResponseCollection = {
   data: Array<GeneralEntity>;
 };
 
-export type GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsExploreSection | ComponentSectionsGallerySection | ComponentSectionsHighlightsSection | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartnersSection | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage;
+export type GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsExploreSection | ComponentSectionsGallerySection | ComponentSectionsHighlightsSection | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartnersSection | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Menu | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage;
 
 export type GetInvolvedPage = {
   __typename?: 'GetInvolvedPage';
@@ -1303,6 +1330,42 @@ export type MainPageRelationResponseCollection = {
 
 export type MainPageSectionsDynamicZone = ComponentSectionsExploreSection | ComponentSectionsHighlightsSection | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartnersSection | ComponentSectionsRichtextSection | ComponentSectionsTicketsSection | Error;
 
+export type Menu = {
+  __typename?: 'Menu';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<MenuRelationResponseCollection>;
+  menuLinks?: Maybe<Array<Maybe<ComponentBlocksMenuLinkItem>>>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+
+export type MenuMenuLinksArgs = {
+  filters?: InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type MenuEntity = {
+  __typename?: 'MenuEntity';
+  attributes?: Maybe<Menu>;
+  id?: Maybe<Scalars['ID']>;
+};
+
+export type MenuEntityResponse = {
+  __typename?: 'MenuEntityResponse';
+  data?: Maybe<MenuEntity>;
+};
+
+export type MenuInput = {
+  menuLinks?: InputMaybe<Array<InputMaybe<ComponentBlocksMenuLinkItemInput>>>;
+};
+
+export type MenuRelationResponseCollection = {
+  __typename?: 'MenuRelationResponseCollection';
+  data: Array<MenuEntity>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   /** Change user password. Confirm with the current password. */
@@ -1320,6 +1383,7 @@ export type Mutation = {
   createHomePageLocalization?: Maybe<HomePageEntityResponse>;
   createMainPage?: Maybe<MainPageEntityResponse>;
   createMainPageLocalization?: Maybe<MainPageEntityResponse>;
+  createMenuLocalization?: Maybe<MenuEntityResponse>;
   createPartner?: Maybe<PartnerEntityResponse>;
   createPartnerLocalization?: Maybe<PartnerEntityResponse>;
   createPlace?: Maybe<PlaceEntityResponse>;
@@ -1347,6 +1411,7 @@ export type Mutation = {
   deleteGetInvolvedPage?: Maybe<GetInvolvedPageEntityResponse>;
   deleteHomePage?: Maybe<HomePageEntityResponse>;
   deleteMainPage?: Maybe<MainPageEntityResponse>;
+  deleteMenu?: Maybe<MenuEntityResponse>;
   deletePartner?: Maybe<PartnerEntityResponse>;
   deletePlace?: Maybe<PlaceEntityResponse>;
   deleteTag?: Maybe<TagEntityResponse>;
@@ -1381,6 +1446,7 @@ export type Mutation = {
   updateGetInvolvedPage?: Maybe<GetInvolvedPageEntityResponse>;
   updateHomePage?: Maybe<HomePageEntityResponse>;
   updateMainPage?: Maybe<MainPageEntityResponse>;
+  updateMenu?: Maybe<MenuEntityResponse>;
   updatePartner?: Maybe<PartnerEntityResponse>;
   updatePlace?: Maybe<PlaceEntityResponse>;
   updateTag?: Maybe<TagEntityResponse>;
@@ -1487,6 +1553,13 @@ export type MutationCreateMainPageArgs = {
 
 export type MutationCreateMainPageLocalizationArgs = {
   data?: InputMaybe<MainPageInput>;
+  id?: InputMaybe<Scalars['ID']>;
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
+};
+
+
+export type MutationCreateMenuLocalizationArgs = {
+  data?: InputMaybe<MenuInput>;
   id?: InputMaybe<Scalars['ID']>;
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
@@ -1633,6 +1706,11 @@ export type MutationDeleteHomePageArgs = {
 
 export type MutationDeleteMainPageArgs = {
   id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
+};
+
+
+export type MutationDeleteMenuArgs = {
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
 
@@ -1797,6 +1875,12 @@ export type MutationUpdateHomePageArgs = {
 export type MutationUpdateMainPageArgs = {
   data: MainPageInput;
   id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
+};
+
+
+export type MutationUpdateMenuArgs = {
+  data: MenuInput;
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
 
@@ -2046,6 +2130,7 @@ export type Query = {
   mainPage?: Maybe<MainPageEntityResponse>;
   mainPages?: Maybe<MainPageEntityResponseCollection>;
   me?: Maybe<UsersPermissionsMe>;
+  menu?: Maybe<MenuEntityResponse>;
   partner?: Maybe<PartnerEntityResponse>;
   partners?: Maybe<PartnerEntityResponseCollection>;
   place?: Maybe<PlaceEntityResponse>;
@@ -2166,6 +2251,11 @@ export type QueryMainPagesArgs = {
   pagination?: InputMaybe<PaginationArg>;
   publicationState?: InputMaybe<PublicationState>;
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+
+export type QueryMenuArgs = {
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
 
 
@@ -3022,6 +3112,8 @@ export type SeoFragment = { __typename?: 'ComponentBlocksSeo', metaTitle?: strin
 
 export type LinksFragment = { __typename?: 'ComponentBlocksLinks', title?: string | null, links?: Array<{ __typename?: 'ComponentBlocksLinkItem', title: string, url?: string | null, newWindow?: boolean | null } | null> | null };
 
+export type MenuEntityFragment = { __typename?: 'MenuEntity', id?: string | null, attributes?: { __typename?: 'Menu', menuLinks?: Array<{ __typename?: 'ComponentBlocksMenuLinkItem', id: string, title: string, url?: string | null, hasButtonStyle?: boolean | null, mainPage?: { __typename?: 'MainPageEntityResponse', data?: { __typename?: 'MainPageEntity', id?: string | null, attributes?: { __typename?: 'MainPage', title: string, slug: string, sections?: Array<{ __typename: 'ComponentSectionsExploreSection', id: string, title?: string | null } | { __typename: 'ComponentSectionsHighlightsSection', id: string, highlights?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsMapSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsletterSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsOpeningHoursSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsPageSection', id: string, title?: string | null, submenuTitle?: string | null, layout?: Enum_Componentsectionspagesection_Layout | null, contentPages?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsPartnersSection', id: string, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsTicketsSection', id: string, title?: string | null, submenuTitle?: string | null, text?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'MainPageRelationResponseCollection', data: Array<{ __typename?: 'MainPageEntity', attributes?: { __typename?: 'MainPage', slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null> | null } | null };
+
 export type MainPageEntityFragment = { __typename?: 'MainPageEntity', id?: string | null, attributes?: { __typename?: 'MainPage', title: string, slug: string, sections?: Array<{ __typename: 'ComponentSectionsExploreSection', id: string, title?: string | null } | { __typename: 'ComponentSectionsHighlightsSection', id: string, highlights?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsMapSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsletterSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsOpeningHoursSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsPageSection', id: string, title?: string | null, submenuTitle?: string | null, layout?: Enum_Componentsectionspagesection_Layout | null, contentPages?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsPartnersSection', id: string, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsTicketsSection', id: string, title?: string | null, submenuTitle?: string | null, text?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'MainPageRelationResponseCollection', data: Array<{ __typename?: 'MainPageEntity', attributes?: { __typename?: 'MainPage', slug: string, locale?: string | null } | null }> } | null } | null };
 
 export type ContentPageEntityFragment = { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', title: string, titleToShow?: string | null, subtitle?: string | null, useDatetimeAsSubtitle?: boolean | null, slug: string, addedAt?: any | null, perex?: string | null, color?: string | null, inheritColorFromParent?: boolean | null, sellTickets?: boolean | null, purchaseId?: string | null, showShareButtons?: boolean | null, relatedContentTitle?: string | null, relatedContentSubmenuTitle?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, mainContent?: Array<{ __typename: 'ComponentSectionsAudioSection', id: string, title?: string | null, submenuTitle?: string | null, url?: string | null } | { __typename: 'ComponentSectionsContactCardsSection', id: string, title?: string | null, submenuTitle?: string | null, contacts?: Array<{ __typename?: 'ComponentBlocksContactCardItem', contactCard?: { __typename?: 'ContactCardEntityResponse', data?: { __typename?: 'ContactCardEntity', id?: string | null, attributes?: { __typename?: 'ContactCard', name: string, position?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsGallerySection', id: string, title?: string | null, submenuTitle?: string | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', formats?: any | null, caption?: string | null, url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null }> } | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsVideoSection', id: string, title?: string | null, submenuTitle?: string | null, url?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, slider?: { __typename?: 'ComponentSectionsSliderSection', id: string, submenuTitle?: string | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null }> } | null } | null, downloadSection?: { __typename?: 'ComponentSectionsDownloadSection', id: string, title?: string | null, submenuTitle?: string | null, files?: Array<{ __typename?: 'ComponentBlocksFileItem', id: string, title?: string | null, file: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', name: string, caption?: string | null, alternativeText?: string | null, ext?: string | null, size: number, url: string } | null } | null } } | null> | null } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, childPages?: { __typename?: 'ContentPageRelationResponseCollection', data: Array<{ __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null }> } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'ContentPageRelationResponseCollection', data: Array<{ __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', slug: string, locale?: string | null } | null }> } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | null };
@@ -3039,6 +3131,8 @@ export type HighlightsItemEntityFragment = { __typename?: 'ContentPageEntity', i
 export type HighlightFragment = { __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null };
 
 export type PartnerFragment = { __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null };
+
+export type MenuLinkItemFragment = { __typename?: 'ComponentBlocksMenuLinkItem', id: string, title: string, url?: string | null, hasButtonStyle?: boolean | null, mainPage?: { __typename?: 'MainPageEntityResponse', data?: { __typename?: 'MainPageEntity', id?: string | null, attributes?: { __typename?: 'MainPage', title: string, slug: string, sections?: Array<{ __typename: 'ComponentSectionsExploreSection', id: string, title?: string | null } | { __typename: 'ComponentSectionsHighlightsSection', id: string, highlights?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsMapSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsletterSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsOpeningHoursSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsPageSection', id: string, title?: string | null, submenuTitle?: string | null, layout?: Enum_Componentsectionspagesection_Layout | null, contentPages?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsPartnersSection', id: string, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsTicketsSection', id: string, title?: string | null, submenuTitle?: string | null, text?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'MainPageRelationResponseCollection', data: Array<{ __typename?: 'MainPageEntity', attributes?: { __typename?: 'MainPage', slug: string, locale?: string | null } | null }> } | null } | null } | null } | null };
 
 export type DownloadItemFragment = { __typename?: 'ComponentBlocksFileItem', id: string, title?: string | null, file: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', name: string, caption?: string | null, alternativeText?: string | null, ext?: string | null, size: number, url: string } | null } | null } };
 
@@ -3625,6 +3719,29 @@ export const MainPageEntityFragmentDoc = gql`
 }
     ${MainPageSectionsFragmentDoc}
 ${SeoFragmentDoc}`;
+export const MenuLinkItemFragmentDoc = gql`
+    fragment MenuLinkItem on ComponentBlocksMenuLinkItem {
+  id
+  title
+  url
+  mainPage {
+    data {
+      ...MainPageEntity
+    }
+  }
+  hasButtonStyle
+}
+    ${MainPageEntityFragmentDoc}`;
+export const MenuEntityFragmentDoc = gql`
+    fragment MenuEntity on MenuEntity {
+  id
+  attributes {
+    menuLinks {
+      ...MenuLinkItem
+    }
+  }
+}
+    ${MenuLinkItemFragmentDoc}`;
 export const PartnersFragmentDoc = gql`
     fragment Partners on ContentPage {
   partners(pagination: {limit: 100}) {

--- a/next/src/services/graphql/index.ts
+++ b/next/src/services/graphql/index.ts
@@ -278,6 +278,24 @@ export type ComponentBlocksMenuLinkItem = {
   url?: Maybe<Scalars['String']>;
 };
 
+export type ComponentBlocksMenuLinkItemFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>>>;
+  hasButtonStyle?: InputMaybe<BooleanFilterInput>;
+  mainPage?: InputMaybe<MainPageFiltersInput>;
+  not?: InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>;
+  or?: InputMaybe<Array<InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>>>;
+  title?: InputMaybe<StringFilterInput>;
+  url?: InputMaybe<StringFilterInput>;
+};
+
+export type ComponentBlocksMenuLinkItemInput = {
+  hasButtonStyle?: InputMaybe<Scalars['Boolean']>;
+  id?: InputMaybe<Scalars['ID']>;
+  mainPage?: InputMaybe<Scalars['ID']>;
+  title?: InputMaybe<Scalars['String']>;
+  url?: InputMaybe<Scalars['String']>;
+};
+
 export type ComponentBlocksPalace = {
   __typename?: 'ComponentBlocksPalace';
   address?: Maybe<Scalars['String']>;
@@ -1032,7 +1050,7 @@ export type GeneralRelationResponseCollection = {
   data: Array<GeneralEntity>;
 };
 
-export type GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage;
+export type GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Menu | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage;
 
 export type GetInvolvedPage = {
   __typename?: 'GetInvolvedPage';
@@ -1306,6 +1324,42 @@ export type MainPageRelationResponseCollection = {
 
 export type MainPageSectionsDynamicZone = ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsTicketsSection | Error;
 
+export type Menu = {
+  __typename?: 'Menu';
+  createdAt?: Maybe<Scalars['DateTime']>;
+  locale?: Maybe<Scalars['String']>;
+  localizations?: Maybe<MenuRelationResponseCollection>;
+  menuLinks?: Maybe<Array<Maybe<ComponentBlocksMenuLinkItem>>>;
+  updatedAt?: Maybe<Scalars['DateTime']>;
+};
+
+
+export type MenuMenuLinksArgs = {
+  filters?: InputMaybe<ComponentBlocksMenuLinkItemFiltersInput>;
+  pagination?: InputMaybe<PaginationArg>;
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+export type MenuEntity = {
+  __typename?: 'MenuEntity';
+  attributes?: Maybe<Menu>;
+  id?: Maybe<Scalars['ID']>;
+};
+
+export type MenuEntityResponse = {
+  __typename?: 'MenuEntityResponse';
+  data?: Maybe<MenuEntity>;
+};
+
+export type MenuInput = {
+  menuLinks?: InputMaybe<Array<InputMaybe<ComponentBlocksMenuLinkItemInput>>>;
+};
+
+export type MenuRelationResponseCollection = {
+  __typename?: 'MenuRelationResponseCollection';
+  data: Array<MenuEntity>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   /** Change user password. Confirm with the current password. */
@@ -1323,6 +1377,7 @@ export type Mutation = {
   createHomePageLocalization?: Maybe<HomePageEntityResponse>;
   createMainPage?: Maybe<MainPageEntityResponse>;
   createMainPageLocalization?: Maybe<MainPageEntityResponse>;
+  createMenuLocalization?: Maybe<MenuEntityResponse>;
   createPartner?: Maybe<PartnerEntityResponse>;
   createPartnerLocalization?: Maybe<PartnerEntityResponse>;
   createPlace?: Maybe<PlaceEntityResponse>;
@@ -1350,6 +1405,7 @@ export type Mutation = {
   deleteGetInvolvedPage?: Maybe<GetInvolvedPageEntityResponse>;
   deleteHomePage?: Maybe<HomePageEntityResponse>;
   deleteMainPage?: Maybe<MainPageEntityResponse>;
+  deleteMenu?: Maybe<MenuEntityResponse>;
   deletePartner?: Maybe<PartnerEntityResponse>;
   deletePlace?: Maybe<PlaceEntityResponse>;
   deleteTag?: Maybe<TagEntityResponse>;
@@ -1384,6 +1440,7 @@ export type Mutation = {
   updateGetInvolvedPage?: Maybe<GetInvolvedPageEntityResponse>;
   updateHomePage?: Maybe<HomePageEntityResponse>;
   updateMainPage?: Maybe<MainPageEntityResponse>;
+  updateMenu?: Maybe<MenuEntityResponse>;
   updatePartner?: Maybe<PartnerEntityResponse>;
   updatePlace?: Maybe<PlaceEntityResponse>;
   updateTag?: Maybe<TagEntityResponse>;
@@ -1490,6 +1547,13 @@ export type MutationCreateMainPageArgs = {
 
 export type MutationCreateMainPageLocalizationArgs = {
   data?: InputMaybe<MainPageInput>;
+  id?: InputMaybe<Scalars['ID']>;
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
+};
+
+
+export type MutationCreateMenuLocalizationArgs = {
+  data?: InputMaybe<MenuInput>;
   id?: InputMaybe<Scalars['ID']>;
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
@@ -1636,6 +1700,11 @@ export type MutationDeleteHomePageArgs = {
 
 export type MutationDeleteMainPageArgs = {
   id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
+};
+
+
+export type MutationDeleteMenuArgs = {
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
 
@@ -1800,6 +1869,12 @@ export type MutationUpdateHomePageArgs = {
 export type MutationUpdateMainPageArgs = {
   data: MainPageInput;
   id: Scalars['ID'];
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
+};
+
+
+export type MutationUpdateMenuArgs = {
+  data: MenuInput;
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
 
@@ -2049,6 +2124,7 @@ export type Query = {
   mainPage?: Maybe<MainPageEntityResponse>;
   mainPages?: Maybe<MainPageEntityResponseCollection>;
   me?: Maybe<UsersPermissionsMe>;
+  menu?: Maybe<MenuEntityResponse>;
   partner?: Maybe<PartnerEntityResponse>;
   partners?: Maybe<PartnerEntityResponseCollection>;
   place?: Maybe<PlaceEntityResponse>;
@@ -2169,6 +2245,11 @@ export type QueryMainPagesArgs = {
   pagination?: InputMaybe<PaginationArg>;
   publicationState?: InputMaybe<PublicationState>;
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+
+export type QueryMenuArgs = {
+  locale?: InputMaybe<Scalars['I18NLocaleCode']>;
 };
 
 
@@ -3025,6 +3106,8 @@ export type SeoFragment = { __typename?: 'ComponentBlocksSeo', metaTitle?: strin
 
 export type LinksFragment = { __typename?: 'ComponentBlocksLinks', title?: string | null, links?: Array<{ __typename?: 'ComponentBlocksLinkItem', title: string, url?: string | null, newWindow?: boolean | null } | null> | null };
 
+export type MenuEntityFragment = { __typename?: 'MenuEntity', id?: string | null, attributes?: { __typename?: 'Menu', menuLinks?: Array<{ __typename?: 'ComponentBlocksMenuLinkItem', id: string, title: string, url?: string | null, hasButtonStyle?: boolean | null, mainPage?: { __typename?: 'MainPageEntityResponse', data?: { __typename?: 'MainPageEntity', id?: string | null, attributes?: { __typename?: 'MainPage', title: string, slug: string, sections?: Array<{ __typename: 'ComponentSectionsHighlights', id: string, highlights?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsMapSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsletterSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsOpeningHoursSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsPageSection', id: string, title?: string | null, submenuTitle?: string | null, layout?: Enum_Componentsectionspagesection_Layout | null, contentPages?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsPartners', id: string, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsTicketsSection', id: string, title?: string | null, submenuTitle?: string | null, text?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'MainPageRelationResponseCollection', data: Array<{ __typename?: 'MainPageEntity', attributes?: { __typename?: 'MainPage', slug: string, locale?: string | null } | null }> } | null } | null } | null } | null } | null> | null } | null };
+
 export type MainPageEntityFragment = { __typename?: 'MainPageEntity', id?: string | null, attributes?: { __typename?: 'MainPage', title: string, slug: string, sections?: Array<{ __typename: 'ComponentSectionsHighlights', id: string, highlights?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', titleToShow?: string | null, sellTickets?: boolean | null, purchaseId?: string | null, perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, override?: { __typename?: 'ComponentBlocksHighlightOverride', highlightContent?: string | null } | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsMapSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsSection', id: string, title?: string | null, submenuTitle?: string | null } | { __typename: 'ComponentSectionsNewsletterSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsOpeningHoursSection', id: string, submenuTitle?: string | null } | { __typename: 'ComponentSectionsPageSection', id: string, title?: string | null, submenuTitle?: string | null, layout?: Enum_Componentsectionspagesection_Layout | null, contentPages?: Array<{ __typename?: 'ComponentBlocksContentPageItem', contentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsPartners', id: string, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsTicketsSection', id: string, title?: string | null, submenuTitle?: string | null, text?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'MainPageRelationResponseCollection', data: Array<{ __typename?: 'MainPageEntity', attributes?: { __typename?: 'MainPage', slug: string, locale?: string | null } | null }> } | null } | null };
 
 export type ContentPageEntityFragment = { __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', title: string, titleToShow?: string | null, subtitle?: string | null, useDatetimeAsSubtitle?: boolean | null, slug: string, addedAt?: any | null, perex?: string | null, color?: string | null, inheritColorFromParent?: boolean | null, sellTickets?: boolean | null, purchaseId?: string | null, showShareButtons?: boolean | null, relatedContentTitle?: string | null, relatedContentSubmenuTitle?: string | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, placeTitle?: string | null, placeAddress?: string | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, mainContent?: Array<{ __typename: 'ComponentSectionsAudioSection', id: string, title?: string | null, submenuTitle?: string | null, url?: string | null } | { __typename: 'ComponentSectionsContactCardsSection', id: string, title?: string | null, submenuTitle?: string | null, contacts?: Array<{ __typename?: 'ComponentBlocksContactCardItem', contactCard?: { __typename?: 'ContactCardEntityResponse', data?: { __typename?: 'ContactCardEntity', id?: string | null, attributes?: { __typename?: 'ContactCard', name: string, position?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null } | null> | null } | { __typename: 'ComponentSectionsGallerySection', id: string, title?: string | null, submenuTitle?: string | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', formats?: any | null, caption?: string | null, url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null }> } | null } | { __typename: 'ComponentSectionsRichtextSection', id: string, submenuTitle?: string | null, content?: string | null } | { __typename: 'ComponentSectionsVideoSection', id: string, title?: string | null, submenuTitle?: string | null, url?: string | null } | { __typename?: 'Error', code: string, message?: string | null } | null> | null, slider?: { __typename?: 'ComponentSectionsSliderSection', id: string, submenuTitle?: string | null, medias?: { __typename?: 'UploadFileRelationResponseCollection', data: Array<{ __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null }> } | null } | null, downloadSection?: { __typename?: 'ComponentSectionsDownloadSection', id: string, title?: string | null, submenuTitle?: string | null, files?: Array<{ __typename?: 'ComponentBlocksFileItem', id: string, title?: string | null, file: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', name: string, caption?: string | null, alternativeText?: string | null, ext?: string | null, size: number, url: string } | null } | null } } | null> | null } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null, childPages?: { __typename?: 'ContentPageRelationResponseCollection', data: Array<{ __typename?: 'ContentPageEntity', id?: string | null, attributes?: { __typename?: 'ContentPage', perex?: string | null, title: string, subtitle?: string | null, addedAt?: any | null, useDatetimeAsSubtitle?: boolean | null, slug: string, color?: string | null, inheritColorFromParent?: boolean | null, dateFrom?: any | null, dateTo?: any | null, timeFrom?: any | null, timeTo?: any | null, showRemainingTime?: boolean | null, coverMedia?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, parentPage?: { __typename?: 'ContentPageEntityResponse', data?: { __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', color?: string | null } | null } | null } | null } | null }> } | null, tags?: { __typename?: 'TagRelationResponseCollection', data: Array<{ __typename?: 'TagEntity', attributes?: { __typename?: 'Tag', title: string, slug: string } | null }> } | null, seo?: { __typename?: 'ComponentBlocksSeo', metaTitle?: string | null, metaDescription?: string | null, keywords?: string | null, metaImage?: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } | null } | null, localizations?: { __typename?: 'ContentPageRelationResponseCollection', data: Array<{ __typename?: 'ContentPageEntity', attributes?: { __typename?: 'ContentPage', slug: string, locale?: string | null } | null }> } | null, place?: { __typename?: 'PlaceEntityResponse', data?: { __typename?: 'PlaceEntity', attributes?: { __typename?: 'Place', title: string, address: string, slug: string, purchaseId?: string | null } | null } | null } | null, positions?: Array<{ __typename?: 'ComponentBlocksPositionItem', title?: string | null, names?: string | null } | null> | null, partners?: Array<{ __typename?: 'ComponentBlocksPartnerItem', partner?: { __typename?: 'PartnerEntityResponse', data?: { __typename?: 'PartnerEntity', id?: string | null, attributes?: { __typename?: 'Partner', title: string, link?: string | null, logo: { __typename?: 'UploadFileEntityResponse', data?: { __typename?: 'UploadFileEntity', attributes?: { __typename?: 'UploadFile', url: string, alternativeText?: string | null, width?: number | null, height?: number | null } | null } | null } } | null } | null } | null } | null> | null } | null };
@@ -3297,6 +3380,27 @@ export const TicketEntityFragmentDoc = gql`
   }
 }
     `;
+export const NewsItemEntityFragmentDoc = gql`
+    fragment NewsItemEntity on ContentPageEntity {
+  id
+  attributes {
+    title
+    subtitle
+    addedAt
+    useDatetimeAsSubtitle
+    slug
+    color
+    inheritColorFromParent
+    parentPage {
+      data {
+        attributes {
+          color
+        }
+      }
+    }
+  }
+}
+    `;
 export const ImageEntityFragmentDoc = gql`
     fragment ImageEntity on UploadFileEntity {
   attributes {
@@ -3316,6 +3420,134 @@ export const DatetimeFragmentDoc = gql`
   showRemainingTime
 }
     `;
+export const TagEntityFragmentDoc = gql`
+    fragment TagEntity on TagEntity {
+  attributes {
+    title
+    slug
+  }
+}
+    `;
+export const SectionItemEntityFragmentDoc = gql`
+    fragment SectionItemEntity on ContentPageEntity {
+  ...NewsItemEntity
+  attributes {
+    perex
+    coverMedia {
+      data {
+        ...ImageEntity
+      }
+    }
+    ...Datetime
+    tags {
+      data {
+        ...TagEntity
+      }
+    }
+  }
+}
+    ${NewsItemEntityFragmentDoc}
+${ImageEntityFragmentDoc}
+${DatetimeFragmentDoc}
+${TagEntityFragmentDoc}`;
+export const PageSectionFragmentDoc = gql`
+    fragment PageSection on ComponentSectionsPageSection {
+  id
+  title
+  submenuTitle
+  layout
+  contentPages {
+    contentPage {
+      data {
+        ...SectionItemEntity
+      }
+    }
+  }
+}
+    ${SectionItemEntityFragmentDoc}`;
+export const NewsSectionFragmentDoc = gql`
+    fragment NewsSection on ComponentSectionsNewsSection {
+  id
+  title
+  submenuTitle
+}
+    `;
+export const OpeningHoursSectionFragmentDoc = gql`
+    fragment OpeningHoursSection on ComponentSectionsOpeningHoursSection {
+  id
+  submenuTitle
+}
+    `;
+export const NewsletterSectionFragmentDoc = gql`
+    fragment NewsletterSection on ComponentSectionsNewsletterSection {
+  id
+  submenuTitle
+}
+    `;
+export const TicketsSectionFragmentDoc = gql`
+    fragment TicketsSection on ComponentSectionsTicketsSection {
+  id
+  title
+  submenuTitle
+  text
+}
+    `;
+export const MapSectionFragmentDoc = gql`
+    fragment MapSection on ComponentSectionsMapSection {
+  id
+  title
+  submenuTitle
+}
+    `;
+export const RichtextSectionFragmentDoc = gql`
+    fragment RichtextSection on ComponentSectionsRichtextSection {
+  id
+  submenuTitle
+  content
+}
+    `;
+export const SectionsFragmentDoc = gql`
+    fragment Sections on VisitUsPageSectionsDynamicZone {
+  ... on Error {
+    code
+    message
+  }
+  ... on ComponentSectionsPageSection {
+    __typename
+    ...PageSection
+  }
+  ... on ComponentSectionsNewsSection {
+    __typename
+    ...NewsSection
+  }
+  ... on ComponentSectionsOpeningHoursSection {
+    __typename
+    ...OpeningHoursSection
+  }
+  ... on ComponentSectionsNewsletterSection {
+    __typename
+    ...NewsletterSection
+  }
+  ... on ComponentSectionsTicketsSection {
+    __typename
+    ...TicketsSection
+  }
+  ... on ComponentSectionsMapSection {
+    __typename
+    ...MapSection
+  }
+  ... on ComponentSectionsRichtextSection {
+    __typename
+    ...RichtextSection
+  }
+}
+    ${PageSectionFragmentDoc}
+${NewsSectionFragmentDoc}
+${OpeningHoursSectionFragmentDoc}
+${NewsletterSectionFragmentDoc}
+${TicketsSectionFragmentDoc}
+${MapSectionFragmentDoc}
+${RichtextSectionFragmentDoc}`;
 export const PlaceEntityFragmentDoc = gql`
     fragment PlaceEntity on PlaceEntity {
   attributes {
@@ -3350,6 +3582,40 @@ export const PositionsFragmentDoc = gql`
   }
 }
     ${PositionFragmentDoc}`;
+export const HighlightsItemEntityFragmentDoc = gql`
+    fragment HighlightsItemEntity on ContentPageEntity {
+  ...SectionItemEntity
+  attributes {
+    titleToShow
+    ...ContentPagePlace
+    ...Positions
+    sellTickets
+    purchaseId
+    override {
+      highlightContent
+    }
+  }
+}
+    ${SectionItemEntityFragmentDoc}
+${ContentPagePlaceFragmentDoc}
+${PositionsFragmentDoc}`;
+export const HighlightFragmentDoc = gql`
+    fragment Highlight on ComponentBlocksContentPageItem {
+  contentPage {
+    data {
+      ...HighlightsItemEntity
+    }
+  }
+}
+    ${HighlightsItemEntityFragmentDoc}`;
+export const HighlightsSectionFragmentDoc = gql`
+    fragment HighlightsSection on ComponentSectionsHighlights {
+  id
+  highlights {
+    ...Highlight
+  }
+}
+    ${HighlightFragmentDoc}`;
 export const PartnerEntityFragmentDoc = gql`
     fragment PartnerEntity on PartnerEntity {
   id
@@ -3364,6 +3630,97 @@ export const PartnerEntityFragmentDoc = gql`
   }
 }
     ${ImageEntityFragmentDoc}`;
+export const PartnerFragmentDoc = gql`
+    fragment Partner on ComponentBlocksPartnerItem {
+  partner {
+    data {
+      ...PartnerEntity
+    }
+  }
+}
+    ${PartnerEntityFragmentDoc}`;
+export const PartnersSectionFragmentDoc = gql`
+    fragment PartnersSection on ComponentSectionsPartners {
+  id
+  partners {
+    ...Partner
+  }
+}
+    ${PartnerFragmentDoc}`;
+export const MainPageSectionsFragmentDoc = gql`
+    fragment MainPageSections on MainPageSectionsDynamicZone {
+  ...Sections
+  ... on ComponentSectionsHighlights {
+    __typename
+    ...HighlightsSection
+  }
+  ... on ComponentSectionsPartners {
+    __typename
+    ...PartnersSection
+  }
+}
+    ${SectionsFragmentDoc}
+${HighlightsSectionFragmentDoc}
+${PartnersSectionFragmentDoc}`;
+export const SeoFragmentDoc = gql`
+    fragment Seo on ComponentBlocksSeo {
+  metaTitle
+  metaDescription
+  keywords
+  metaImage {
+    data {
+      ...ImageEntity
+    }
+  }
+}
+    ${ImageEntityFragmentDoc}`;
+export const MainPageEntityFragmentDoc = gql`
+    fragment MainPageEntity on MainPageEntity {
+  id
+  attributes {
+    title
+    slug
+    sections {
+      ...MainPageSections
+    }
+    seo {
+      ...Seo
+    }
+    localizations {
+      data {
+        attributes {
+          slug
+          locale
+        }
+      }
+    }
+  }
+}
+    ${MainPageSectionsFragmentDoc}
+${SeoFragmentDoc}`;
+export const MenuLinkItemFragmentDoc = gql`
+    fragment MenuLinkItem on ComponentBlocksMenuLinkItem {
+  id
+  title
+  url
+  mainPage {
+    data {
+      ...MainPageEntity
+    }
+  }
+  hasButtonStyle
+}
+    ${MainPageEntityFragmentDoc}`;
+export const MenuEntityFragmentDoc = gql`
+    fragment MenuEntity on MenuEntity {
+  id
+  attributes {
+    menuLinks {
+      ...MenuLinkItem
+    }
+  }
+}
+    ${MenuLinkItemFragmentDoc}`;
 export const PartnersFragmentDoc = gql`
     fragment Partners on ContentPage {
   partners(pagination: {limit: 100}) {
@@ -3375,13 +3732,6 @@ export const PartnersFragmentDoc = gql`
   }
 }
     ${PartnerEntityFragmentDoc}`;
-export const RichtextSectionFragmentDoc = gql`
-    fragment RichtextSection on ComponentSectionsRichtextSection {
-  id
-  submenuTitle
-  content
-}
-    `;
 export const VideoSectionFragmentDoc = gql`
     fragment VideoSection on ComponentSectionsVideoSection {
   id
@@ -3516,69 +3866,6 @@ export const DownloadSectionFragmentDoc = gql`
   }
 }
     ${DownloadItemFragmentDoc}`;
-export const NewsItemEntityFragmentDoc = gql`
-    fragment NewsItemEntity on ContentPageEntity {
-  id
-  attributes {
-    title
-    subtitle
-    addedAt
-    useDatetimeAsSubtitle
-    slug
-    color
-    inheritColorFromParent
-    parentPage {
-      data {
-        attributes {
-          color
-        }
-      }
-    }
-  }
-}
-    `;
-export const TagEntityFragmentDoc = gql`
-    fragment TagEntity on TagEntity {
-  attributes {
-    title
-    slug
-  }
-}
-    `;
-export const SectionItemEntityFragmentDoc = gql`
-    fragment SectionItemEntity on ContentPageEntity {
-  ...NewsItemEntity
-  attributes {
-    perex
-    coverMedia {
-      data {
-        ...ImageEntity
-      }
-    }
-    ...Datetime
-    tags {
-      data {
-        ...TagEntity
-      }
-    }
-  }
-}
-    ${NewsItemEntityFragmentDoc}
-${ImageEntityFragmentDoc}
-${DatetimeFragmentDoc}
-${TagEntityFragmentDoc}`;
-export const SeoFragmentDoc = gql`
-    fragment Seo on ComponentBlocksSeo {
-  metaTitle
-  metaDescription
-  keywords
-  metaImage {
-    data {
-      ...ImageEntity
-    }
-  }
-}
-    ${ImageEntityFragmentDoc}`;
 export const ContentPageEntityFragmentDoc = gql`
     fragment ContentPageEntity on ContentPageEntity {
   id
@@ -3665,200 +3952,6 @@ export const CommonSearchPageEntityFragmentDoc = gql`
   }
 }
     `;
-export const PageSectionFragmentDoc = gql`
-    fragment PageSection on ComponentSectionsPageSection {
-  id
-  title
-  submenuTitle
-  layout
-  contentPages {
-    contentPage {
-      data {
-        ...SectionItemEntity
-      }
-    }
-  }
-}
-    ${SectionItemEntityFragmentDoc}`;
-export const NewsSectionFragmentDoc = gql`
-    fragment NewsSection on ComponentSectionsNewsSection {
-  id
-  title
-  submenuTitle
-}
-    `;
-export const OpeningHoursSectionFragmentDoc = gql`
-    fragment OpeningHoursSection on ComponentSectionsOpeningHoursSection {
-  id
-  submenuTitle
-}
-    `;
-export const NewsletterSectionFragmentDoc = gql`
-    fragment NewsletterSection on ComponentSectionsNewsletterSection {
-  id
-  submenuTitle
-}
-    `;
-export const TicketsSectionFragmentDoc = gql`
-    fragment TicketsSection on ComponentSectionsTicketsSection {
-  id
-  title
-  submenuTitle
-  text
-}
-    `;
-export const MapSectionFragmentDoc = gql`
-    fragment MapSection on ComponentSectionsMapSection {
-  id
-  title
-  submenuTitle
-}
-    `;
-export const SectionsFragmentDoc = gql`
-    fragment Sections on VisitUsPageSectionsDynamicZone {
-  ... on Error {
-    code
-    message
-  }
-  ... on ComponentSectionsPageSection {
-    __typename
-    ...PageSection
-  }
-  ... on ComponentSectionsNewsSection {
-    __typename
-    ...NewsSection
-  }
-  ... on ComponentSectionsOpeningHoursSection {
-    __typename
-    ...OpeningHoursSection
-  }
-  ... on ComponentSectionsNewsletterSection {
-    __typename
-    ...NewsletterSection
-  }
-  ... on ComponentSectionsTicketsSection {
-    __typename
-    ...TicketsSection
-  }
-  ... on ComponentSectionsMapSection {
-    __typename
-    ...MapSection
-  }
-  ... on ComponentSectionsRichtextSection {
-    __typename
-    ...RichtextSection
-  }
-}
-    ${PageSectionFragmentDoc}
-${NewsSectionFragmentDoc}
-${OpeningHoursSectionFragmentDoc}
-${NewsletterSectionFragmentDoc}
-${TicketsSectionFragmentDoc}
-${MapSectionFragmentDoc}
-${RichtextSectionFragmentDoc}`;
-export const HighlightsItemEntityFragmentDoc = gql`
-    fragment HighlightsItemEntity on ContentPageEntity {
-  ...SectionItemEntity
-  attributes {
-    titleToShow
-    ...ContentPagePlace
-    ...Positions
-    sellTickets
-    purchaseId
-    override {
-      highlightContent
-    }
-  }
-}
-    ${SectionItemEntityFragmentDoc}
-${ContentPagePlaceFragmentDoc}
-${PositionsFragmentDoc}`;
-export const HighlightFragmentDoc = gql`
-    fragment Highlight on ComponentBlocksContentPageItem {
-  contentPage {
-    data {
-      ...HighlightsItemEntity
-    }
-  }
-}
-    ${HighlightsItemEntityFragmentDoc}`;
-export const HighlightsSectionFragmentDoc = gql`
-    fragment HighlightsSection on ComponentSectionsHighlights {
-  id
-  highlights {
-    ...Highlight
-  }
-}
-    ${HighlightFragmentDoc}`;
-export const PartnerFragmentDoc = gql`
-    fragment Partner on ComponentBlocksPartnerItem {
-  partner {
-    data {
-      ...PartnerEntity
-    }
-  }
-}
-    ${PartnerEntityFragmentDoc}`;
-export const PartnersSectionFragmentDoc = gql`
-    fragment PartnersSection on ComponentSectionsPartners {
-  id
-  partners {
-    ...Partner
-  }
-}
-    ${PartnerFragmentDoc}`;
-export const MainPageSectionsFragmentDoc = gql`
-    fragment MainPageSections on MainPageSectionsDynamicZone {
-  ...Sections
-  ... on ComponentSectionsHighlights {
-    __typename
-    ...HighlightsSection
-  }
-  ... on ComponentSectionsPartners {
-    __typename
-    ...PartnersSection
-  }
-}
-    ${SectionsFragmentDoc}
-${HighlightsSectionFragmentDoc}
-${PartnersSectionFragmentDoc}`;
-export const MainPageEntityFragmentDoc = gql`
-    fragment MainPageEntity on MainPageEntity {
-  id
-  attributes {
-    title
-    slug
-    sections {
-      ...MainPageSections
-    }
-    seo {
-      ...Seo
-    }
-    localizations {
-      data {
-        attributes {
-          slug
-          locale
-        }
-      }
-    }
-  }
-}
-    ${MainPageSectionsFragmentDoc}
-${SeoFragmentDoc}`;
-export const MenuLinkItemFragmentDoc = gql`
-    fragment MenuLinkItem on ComponentBlocksMenuLinkItem {
-  id
-  title
-  url
-  mainPage {
-    data {
-      ...MainPageEntity
-    }
-  }
-  hasButtonStyle
-}
-    ${MainPageEntityFragmentDoc}`;
 export const PalaceDetailsFragmentDoc = gql`
     fragment PalaceDetails on ComponentBlocksPalace {
   title

--- a/next/src/services/graphql/queries/fragments.gql
+++ b/next/src/services/graphql/queries/fragments.gql
@@ -124,6 +124,15 @@ fragment Links on ComponentBlocksLinks {
   }
 }
 
+fragment MenuEntity on MenuEntity {
+  id
+  attributes {
+    menuLinks {
+      ...MenuLinkItem
+    }
+  }
+}
+
 fragment MainPageEntity on MainPageEntity {
   id
   attributes {

--- a/next/src/services/graphql/queries/fragments.gql
+++ b/next/src/services/graphql/queries/fragments.gql
@@ -300,6 +300,18 @@ fragment Partner on ComponentBlocksPartnerItem {
   }
 }
 
+fragment MenuLinkItem on ComponentBlocksMenuLinkItem {
+  id
+  title
+  url
+  mainPage {
+    data {
+      ...MainPageEntity
+    }
+  }
+  hasButtonStyle
+}
+
 fragment DownloadItem on ComponentBlocksFileItem {
   id
   title

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -268,6 +268,32 @@ input ComponentBlocksLinksInput {
   title: String
 }
 
+type ComponentBlocksMenuLinkItem {
+  hasButtonStyle: Boolean
+  id: ID!
+  mainPage: MainPageEntityResponse
+  title: String!
+  url: String
+}
+
+input ComponentBlocksMenuLinkItemFiltersInput {
+  and: [ComponentBlocksMenuLinkItemFiltersInput]
+  hasButtonStyle: BooleanFilterInput
+  mainPage: MainPageFiltersInput
+  not: ComponentBlocksMenuLinkItemFiltersInput
+  or: [ComponentBlocksMenuLinkItemFiltersInput]
+  title: StringFilterInput
+  url: StringFilterInput
+}
+
+input ComponentBlocksMenuLinkItemInput {
+  hasButtonStyle: Boolean
+  id: ID
+  mainPage: ID
+  title: String
+  url: String
+}
+
 type ComponentBlocksPalace {
   address: String
   city: String
@@ -1170,7 +1196,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsExploreSection | ComponentSectionsGallerySection | ComponentSectionsHighlightsSection | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartnersSection | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage
+union GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsExploreSection | ComponentSectionsGallerySection | ComponentSectionsHighlightsSection | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartnersSection | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Menu | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage
 
 type GetInvolvedPage {
   createdAt: DateTime
@@ -1486,6 +1512,47 @@ union MainPageSectionsDynamicZone = ComponentSectionsExploreSection | ComponentS
 
 scalar MainPageSectionsDynamicZoneInput
 
+type Menu {
+  createdAt: DateTime
+  locale: String
+  localizations: MenuRelationResponseCollection
+  menuLinks(filters: ComponentBlocksMenuLinkItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksMenuLinkItem]
+  updatedAt: DateTime
+}
+
+type MenuEntity {
+  attributes: Menu
+  id: ID
+}
+
+type MenuEntityResponse {
+  data: MenuEntity
+}
+
+type MenuEntityResponseCollection {
+  data: [MenuEntity!]!
+  meta: ResponseCollectionMeta!
+}
+
+input MenuFiltersInput {
+  and: [MenuFiltersInput]
+  createdAt: DateTimeFilterInput
+  locale: StringFilterInput
+  localizations: MenuFiltersInput
+  menuLinks: ComponentBlocksMenuLinkItemFiltersInput
+  not: MenuFiltersInput
+  or: [MenuFiltersInput]
+  updatedAt: DateTimeFilterInput
+}
+
+input MenuInput {
+  menuLinks: [ComponentBlocksMenuLinkItemInput]
+}
+
+type MenuRelationResponseCollection {
+  data: [MenuEntity!]!
+}
+
 type Mutation {
   """Change user password. Confirm with the current password."""
   changePassword(currentPassword: String!, password: String!, passwordConfirmation: String!): UsersPermissionsLoginPayload
@@ -1502,6 +1569,7 @@ type Mutation {
   createHomePageLocalization(data: HomePageInput, id: ID, locale: I18NLocaleCode): HomePageEntityResponse
   createMainPage(data: MainPageInput!, locale: I18NLocaleCode): MainPageEntityResponse
   createMainPageLocalization(data: MainPageInput, id: ID, locale: I18NLocaleCode): MainPageEntityResponse
+  createMenuLocalization(data: MenuInput, id: ID, locale: I18NLocaleCode): MenuEntityResponse
   createPartner(data: PartnerInput!, locale: I18NLocaleCode): PartnerEntityResponse
   createPartnerLocalization(data: PartnerInput, id: ID, locale: I18NLocaleCode): PartnerEntityResponse
   createPlace(data: PlaceInput!, locale: I18NLocaleCode): PlaceEntityResponse
@@ -1531,6 +1599,7 @@ type Mutation {
   deleteGetInvolvedPage(locale: I18NLocaleCode): GetInvolvedPageEntityResponse
   deleteHomePage(locale: I18NLocaleCode): HomePageEntityResponse
   deleteMainPage(id: ID!, locale: I18NLocaleCode): MainPageEntityResponse
+  deleteMenu(locale: I18NLocaleCode): MenuEntityResponse
   deletePartner(id: ID!, locale: I18NLocaleCode): PartnerEntityResponse
   deletePlace(id: ID!, locale: I18NLocaleCode): PlaceEntityResponse
   deleteTag(id: ID!, locale: I18NLocaleCode): TagEntityResponse
@@ -1573,6 +1642,7 @@ type Mutation {
   updateGetInvolvedPage(data: GetInvolvedPageInput!, locale: I18NLocaleCode): GetInvolvedPageEntityResponse
   updateHomePage(data: HomePageInput!, locale: I18NLocaleCode): HomePageEntityResponse
   updateMainPage(data: MainPageInput!, id: ID!, locale: I18NLocaleCode): MainPageEntityResponse
+  updateMenu(data: MenuInput!, locale: I18NLocaleCode): MenuEntityResponse
   updatePartner(data: PartnerInput!, id: ID!, locale: I18NLocaleCode): PartnerEntityResponse
   updatePlace(data: PlaceInput!, id: ID!, locale: I18NLocaleCode): PlaceEntityResponse
   updateTag(data: TagInput!, id: ID!, locale: I18NLocaleCode): TagEntityResponse
@@ -1728,6 +1798,7 @@ type Query {
   mainPage(id: ID, locale: I18NLocaleCode): MainPageEntityResponse
   mainPages(filters: MainPageFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): MainPageEntityResponseCollection
   me: UsersPermissionsMe
+  menu(locale: I18NLocaleCode): MenuEntityResponse
   partner(id: ID, locale: I18NLocaleCode): PartnerEntityResponse
   partners(filters: PartnerFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, sort: [String] = []): PartnerEntityResponseCollection
   place(id: ID, locale: I18NLocaleCode): PlaceEntityResponse

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -1179,7 +1179,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage
+union GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Menu | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage
 
 type GetInvolvedPage {
   createdAt: DateTime
@@ -1495,6 +1495,47 @@ union MainPageSectionsDynamicZone = ComponentSectionsHighlights | ComponentSecti
 
 scalar MainPageSectionsDynamicZoneInput
 
+type Menu {
+  createdAt: DateTime
+  locale: String
+  localizations: MenuRelationResponseCollection
+  menuLinks(filters: ComponentBlocksMenuLinkItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentBlocksMenuLinkItem]
+  updatedAt: DateTime
+}
+
+type MenuEntity {
+  attributes: Menu
+  id: ID
+}
+
+type MenuEntityResponse {
+  data: MenuEntity
+}
+
+type MenuEntityResponseCollection {
+  data: [MenuEntity!]!
+  meta: ResponseCollectionMeta!
+}
+
+input MenuFiltersInput {
+  and: [MenuFiltersInput]
+  createdAt: DateTimeFilterInput
+  locale: StringFilterInput
+  localizations: MenuFiltersInput
+  menuLinks: ComponentBlocksMenuLinkItemFiltersInput
+  not: MenuFiltersInput
+  or: [MenuFiltersInput]
+  updatedAt: DateTimeFilterInput
+}
+
+input MenuInput {
+  menuLinks: [ComponentBlocksMenuLinkItemInput]
+}
+
+type MenuRelationResponseCollection {
+  data: [MenuEntity!]!
+}
+
 type Mutation {
   """Change user password. Confirm with the current password."""
   changePassword(currentPassword: String!, password: String!, passwordConfirmation: String!): UsersPermissionsLoginPayload
@@ -1511,6 +1552,7 @@ type Mutation {
   createHomePageLocalization(data: HomePageInput, id: ID, locale: I18NLocaleCode): HomePageEntityResponse
   createMainPage(data: MainPageInput!, locale: I18NLocaleCode): MainPageEntityResponse
   createMainPageLocalization(data: MainPageInput, id: ID, locale: I18NLocaleCode): MainPageEntityResponse
+  createMenuLocalization(data: MenuInput, id: ID, locale: I18NLocaleCode): MenuEntityResponse
   createPartner(data: PartnerInput!, locale: I18NLocaleCode): PartnerEntityResponse
   createPartnerLocalization(data: PartnerInput, id: ID, locale: I18NLocaleCode): PartnerEntityResponse
   createPlace(data: PlaceInput!, locale: I18NLocaleCode): PlaceEntityResponse
@@ -1540,6 +1582,7 @@ type Mutation {
   deleteGetInvolvedPage(locale: I18NLocaleCode): GetInvolvedPageEntityResponse
   deleteHomePage(locale: I18NLocaleCode): HomePageEntityResponse
   deleteMainPage(id: ID!, locale: I18NLocaleCode): MainPageEntityResponse
+  deleteMenu(locale: I18NLocaleCode): MenuEntityResponse
   deletePartner(id: ID!, locale: I18NLocaleCode): PartnerEntityResponse
   deletePlace(id: ID!, locale: I18NLocaleCode): PlaceEntityResponse
   deleteTag(id: ID!, locale: I18NLocaleCode): TagEntityResponse
@@ -1582,6 +1625,7 @@ type Mutation {
   updateGetInvolvedPage(data: GetInvolvedPageInput!, locale: I18NLocaleCode): GetInvolvedPageEntityResponse
   updateHomePage(data: HomePageInput!, locale: I18NLocaleCode): HomePageEntityResponse
   updateMainPage(data: MainPageInput!, id: ID!, locale: I18NLocaleCode): MainPageEntityResponse
+  updateMenu(data: MenuInput!, locale: I18NLocaleCode): MenuEntityResponse
   updatePartner(data: PartnerInput!, id: ID!, locale: I18NLocaleCode): PartnerEntityResponse
   updatePlace(data: PlaceInput!, id: ID!, locale: I18NLocaleCode): PlaceEntityResponse
   updateTag(data: TagInput!, id: ID!, locale: I18NLocaleCode): TagEntityResponse
@@ -1737,6 +1781,7 @@ type Query {
   mainPage(id: ID, locale: I18NLocaleCode): MainPageEntityResponse
   mainPages(filters: MainPageFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): MainPageEntityResponseCollection
   me: UsersPermissionsMe
+  menu(locale: I18NLocaleCode): MenuEntityResponse
   partner(id: ID, locale: I18NLocaleCode): PartnerEntityResponse
   partners(filters: PartnerFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, sort: [String] = []): PartnerEntityResponseCollection
   place(id: ID, locale: I18NLocaleCode): PlaceEntityResponse

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -268,6 +268,32 @@ input ComponentBlocksLinksInput {
   title: String
 }
 
+type ComponentBlocksMenuLinkItem {
+  hasButtonStyle: Boolean
+  id: ID!
+  mainPage: MainPageEntityResponse
+  title: String!
+  url: String
+}
+
+input ComponentBlocksMenuLinkItemFiltersInput {
+  and: [ComponentBlocksMenuLinkItemFiltersInput]
+  hasButtonStyle: BooleanFilterInput
+  mainPage: MainPageFiltersInput
+  not: ComponentBlocksMenuLinkItemFiltersInput
+  or: [ComponentBlocksMenuLinkItemFiltersInput]
+  title: StringFilterInput
+  url: StringFilterInput
+}
+
+input ComponentBlocksMenuLinkItemInput {
+  hasButtonStyle: Boolean
+  id: ID
+  mainPage: ID
+  title: String
+  url: String
+}
+
 type ComponentBlocksPalace {
   address: String
   city: String
@@ -1153,7 +1179,7 @@ type GeneralRelationResponseCollection {
   data: [GeneralEntity!]!
 }
 
-union GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage
+union GenericMorph = AboutUsPage | CollectionsPage | ComponentBlocksContactCardItem | ComponentBlocksContentPageItem | ComponentBlocksExhibitionArchive | ComponentBlocksFileItem | ComponentBlocksHighlightOverride | ComponentBlocksLinkItem | ComponentBlocksLinks | ComponentBlocksMenuLinkItem | ComponentBlocksPalace | ComponentBlocksPartnerItem | ComponentBlocksPositionItem | ComponentBlocksSeo | ComponentSectionsArchiveSection | ComponentSectionsAudioSection | ComponentSectionsContactCardsSection | ComponentSectionsDownloadSection | ComponentSectionsGallerySection | ComponentSectionsHighlights | ComponentSectionsMapSection | ComponentSectionsNewsSection | ComponentSectionsNewsletterSection | ComponentSectionsOpeningHoursSection | ComponentSectionsPageSection | ComponentSectionsPartners | ComponentSectionsRichtextSection | ComponentSectionsSliderSection | ComponentSectionsTicketsSection | ComponentSectionsVideoSection | ContactCard | ContentPage | ExhibitionsPage | ExplorePage | General | GetInvolvedPage | HomePage | I18NLocale | MainPage | Partner | Place | Tag | TagCategory | Ticket | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | VisitUsPage
 
 type GetInvolvedPage {
   createdAt: DateTime

--- a/strapi/src/api/menu/content-types/menu/schema.json
+++ b/strapi/src/api/menu/content-types/menu/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "singleType",
+  "collectionName": "menus",
+  "info": {
+    "singularName": "menu",
+    "pluralName": "menus",
+    "displayName": "Menu"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "menuLinks": {
+      "type": "component",
+      "repeatable": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "blocks.menu-link-item"
+    }
+  }
+}

--- a/strapi/src/api/menu/controllers/menu.ts
+++ b/strapi/src/api/menu/controllers/menu.ts
@@ -1,0 +1,7 @@
+/**
+ * menu controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::menu.menu');

--- a/strapi/src/api/menu/routes/menu.ts
+++ b/strapi/src/api/menu/routes/menu.ts
@@ -1,0 +1,7 @@
+/**
+ * menu router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::menu.menu');

--- a/strapi/src/api/menu/services/menu.ts
+++ b/strapi/src/api/menu/services/menu.ts
@@ -1,0 +1,7 @@
+/**
+ * menu service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::menu.menu');

--- a/strapi/src/components/blocks/menu-link-item.json
+++ b/strapi/src/components/blocks/menu-link-item.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_blocks_menu_link_items",
+  "info": {
+    "displayName": "menu link item"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "url": {
+      "type": "string"
+    },
+    "mainPage": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::main-page.main-page"
+    },
+    "hasButtonStyle": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -94,6 +94,23 @@ export interface BlocksLinks extends Schema.Component {
   };
 }
 
+export interface BlocksMenuLinkItem extends Schema.Component {
+  collectionName: 'components_blocks_menu_link_items';
+  info: {
+    displayName: 'menu link item';
+  };
+  attributes: {
+    hasButtonStyle: Attribute.Boolean & Attribute.DefaultTo<false>;
+    mainPage: Attribute.Relation<
+      'blocks.menu-link-item',
+      'oneToOne',
+      'api::main-page.main-page'
+    >;
+    title: Attribute.String & Attribute.Required;
+    url: Attribute.String;
+  };
+}
+
 export interface BlocksPalace extends Schema.Component {
   collectionName: 'components_blocks_palaces';
   info: {
@@ -371,6 +388,7 @@ declare module '@strapi/types' {
       'blocks.highlight-override': BlocksHighlightOverride;
       'blocks.link-item': BlocksLinkItem;
       'blocks.links': BlocksLinks;
+      'blocks.menu-link-item': BlocksMenuLinkItem;
       'blocks.palace': BlocksPalace;
       'blocks.partner-item': BlocksPartnerItem;
       'blocks.position-item': BlocksPositionItem;

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1238,6 +1238,43 @@ export interface ApiMainPageMainPage extends Schema.CollectionType {
   };
 }
 
+export interface ApiMenuMenu extends Schema.SingleType {
+  collectionName: 'menus';
+  info: {
+    displayName: 'Menu';
+    pluralName: 'menus';
+    singularName: 'menu';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    i18n: {
+      localized: true;
+    };
+  };
+  attributes: {
+    createdAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<'api::menu.menu', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+    locale: Attribute.String;
+    localizations: Attribute.Relation<
+      'api::menu.menu',
+      'oneToMany',
+      'api::menu.menu'
+    >;
+    menuLinks: Attribute.Component<'blocks.menu-link-item', true> &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
+    updatedAt: Attribute.DateTime;
+    updatedBy: Attribute.Relation<'api::menu.menu', 'oneToOne', 'admin::user'> &
+      Attribute.Private;
+  };
+}
+
 export interface ApiPartnerPartner extends Schema.CollectionType {
   collectionName: 'partners';
   info: {
@@ -2077,6 +2114,7 @@ declare module '@strapi/types' {
       'api::get-involved-page.get-involved-page': ApiGetInvolvedPageGetInvolvedPage;
       'api::home-page.home-page': ApiHomePageHomePage;
       'api::main-page.main-page': ApiMainPageMainPage;
+      'api::menu.menu': ApiMenuMenu;
       'api::partner.partner': ApiPartnerPartner;
       'api::place.place': ApiPlacePlace;
       'api::tag-category.tag-category': ApiTagCategoryTagCategory;


### PR DESCRIPTION
### Description

- Create single content type `Menu` in Strapi - `Menu` will hold menu links
- Create a menu link component in Strapi that links to an external website or `MainPage` entity

### Screenshots
<img width="781" alt="Screenshot 2025-03-24 at 13 23 09" src="https://github.com/user-attachments/assets/0946a077-fc7d-46e0-b548-f7946e3bc1ae" />

<img width="1287" alt="Screenshot 2025-03-24 at 13 19 36" src="https://github.com/user-attachments/assets/c5c37ffe-ba35-48fe-942d-7d4999161fdf" />
