### PR TITLE
#264 Update homepage title translation to follow a similar pattern as in Marianum

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -22,6 +22,7 @@
   "common.follow": "Follow",
   "common.found": "Found",
   "common.gdprAccept": "I agree with the processing of personal data according to the GDPR",
+  "common.home": "Home",
   "common.loading": "Loading…",
   "common.login": "Sign in",
   "common.moreExhibitions": "More exhibitons and events",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -24,6 +24,7 @@
   "common.follow": "Sleduj",
   "common.found": "Nájdené",
   "common.gdprAccept": "Súhlasím so spracovaním osobných údajov podľa GDPR",
+  "common.home": "Domov",
   "common.loading": "Načítava sa…",
   "common.login": "Prihlásiť",
   "common.moreExhibitions": "Ďalšie výstavy a akcie",

--- a/next/src/pages/index.tsx
+++ b/next/src/pages/index.tsx
@@ -15,17 +15,13 @@ interface IndexProps {
 }
 
 export const Index = ({ homePage, generalQuery, news }: IndexProps) => {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
 
   return (
     <GeneralContextProvider general={generalQuery}>
       <Page
         page={homePage}
-        title={
-          i18n.language === 'sk'
-            ? `${t('common.cityGallery')} ${t('common.bratislavaGenitiv')}`
-            : `${t('common.bratislavaGenitiv')} ${t('common.cityGallery')}`
-        }
+        title={t('common.home')}
         newsItems={news?.data?.filter(hasAttributes)}
       />
     </GeneralContextProvider>


### PR DESCRIPTION
### Description

- The `SeoHead` component is constructing page titles according to this pattern `${title || ''} – ${t('common.bratislavaCityGallery')}` and because of that the homepage's title was _Galéria mesta Bratislavy - Galéria mesta Bratislavy_
- The homepage's title was updated to follow a similar pattern as in Marianum, improving A11Y

### Screenshots

<img width="1277" alt="Screenshot 2025-04-08 at 10 41 11" src="https://github.com/user-attachments/assets/6a6c9637-eea7-4dc9-a8e8-60f76734f12e" />
<img width="1224" alt="Screenshot 2025-04-08 at 12 30 50" src="https://github.com/user-attachments/assets/c56e455d-ebb6-4de7-968e-480f4029d279" />
