### PR TITLE
#264 Ensure that the Card component returns correct URLs for tags

### DIFF
--- a/next/src/components/molecules/presentation/Card.tsx
+++ b/next/src/components/molecules/presentation/Card.tsx
@@ -24,6 +24,9 @@ const Card = ({ sectionItem, showTags }: CardProps) => {
 
   const { slug, coverMedia, title, tags, perex, addedAt, dateFrom, dateTo } = sectionItem.attributes
 
+  const cleanPath = router.asPath.split('?')[0].split('#')[0] // Remove query parameters and hash fragments
+  // Using `asPath` ensures that dynamic segments e.g., [slug] are correctly replaced with actual values
+
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <article className="relative flex min-h-full flex-col gap-y-yMd">
@@ -50,7 +53,7 @@ const Card = ({ sectionItem, showTags }: CardProps) => {
               <Link
                 className=""
                 role="button"
-                href={`${router.pathname}/?tags=${tag.attributes.slug}`}
+                href={`/${cleanPath}/?tags=${tag.attributes.slug}`}
                 key={tag.attributes.slug}
               >
                 {tag.attributes.title}


### PR DESCRIPTION
### Description
- Make sure the `Card` component generates the correct URLs for tags, including for main pages
- Main pages use dynamic segments, so their full URLs can’t be accurately constructed using just the `pathname` from the Next router

### Screenshots

#### Before
<img width="1302" alt="Screenshot 2025-04-14 at 15 40 28" src="https://github.com/user-attachments/assets/52d7ac75-e4fa-4e2e-bae9-1dcd337c6f38" />
<img width="1264" alt="Screenshot 2025-04-14 at 15 40 13" src="https://github.com/user-attachments/assets/6925b108-a8d2-4fcd-915e-d12ec5903db9" />

#### After
<img width="1279" alt="Screenshot 2025-04-14 at 15 42 55" src="https://github.com/user-attachments/assets/8b106306-817d-4780-8e12-3988fa61ae8a" />
