### PR TITLE
#389 Adjust padding for title in DownloadSection component

### DIFF
--- a/next/src/components/molecules/sections/DownloadSection.tsx
+++ b/next/src/components/molecules/sections/DownloadSection.tsx
@@ -16,7 +16,7 @@ const DownloadSection = ({ files, title, anchor }: DownloadSectionProps) => {
 
   return (
     <Section anchor={anchor} color="dark" className="px-xMd py-yLg">
-      {title && <h2 className="pb-yXl text-xxl">{title}</h2>}
+      {title && <h2 className="pb-yLg text-xxl">{title}</h2>}
       <div className="grid grid-flow-row grid-cols-2 gap-x-xMd gap-y-yMd md:grid-cols-3 lg:grid-cols-5">
         {files?.filter(isDefined).map((item) => <DownloadItem downloadItem={item} key={item.id} />)}
       </div>


### PR DESCRIPTION
### Description

- Use pb-yLg in place of pb-yXl

### Screenshots

<img width="989" alt="Screenshot 2025-04-24 at 12 28 27" src="https://github.com/user-attachments/assets/0ceeccd2-8d48-4c5b-b7b4-2bfdbc8f428a" />
