### PR TITLE
#390 Fix padding in DisclosureSection for improved layout

### DIFF
--- a/next/src/components/molecules/sections/DisclosureSection.tsx
+++ b/next/src/components/molecules/sections/DisclosureSection.tsx
@@ -14,7 +14,7 @@ const DisclosureSection = ({ title, anchor, additionalFilesSection }: Disclosure
 
   return (
     <Section title={title ?? t('footer.disclosureOfInformation')} anchor={anchor}>
-      <div className="px-xMd py-yLg">
+      <div className="px-xMd pb-yLg">
         <iframe
           title={t('footer.disclosureOfInformation')}
           src="https://zmluvy.egov.sk/egov/contracts/place:259/iframe/showZmluvy/showFaktury/showObjednavky/orderBy:datum/direction:desc"


### PR DESCRIPTION
### Description
- Remove `lg` top padding from iframe

### Screenshots

<img width="1465" alt="Screenshot 2025-04-24 at 12 52 37" src="https://github.com/user-attachments/assets/8069bbd1-afa2-48ae-b1ad-55a0a96a0b9d" />
