### PR TITLE
#384 Ensure that ImgSwiper is shown only if we receive slide items

### DIFF
--- a/next/src/components/molecules/ImgSwiper.tsx
+++ b/next/src/components/molecules/ImgSwiper.tsx
@@ -23,7 +23,7 @@ const ImgSwiper = ({ slides, anchor }: ImgSwiperProps) => {
   const navigationStyle =
     'absolute cursor-pointer top-1/2 z-10 text-gmbDark font-[swiper-icons] text-[32px] font-heavy -mt-4 select-none'
 
-  return slides ? (
+  return slides?.length ? (
     <Swiper
       loop
       speed={600}

--- a/next/src/components/pages/DetailPage.tsx
+++ b/next/src/components/pages/DetailPage.tsx
@@ -218,7 +218,7 @@ const DetailPage = ({ contentPage }: DetailPageProps) => {
           />
         </div>
       </div>
-      {slider && <ImgSwiper slides={slider?.medias?.data.filter(hasAttributes)} />}
+      {slider ? <ImgSwiper slides={slider?.medias?.data.filter(hasAttributes)} /> : null}
       {relatedContentFiltered.length > 0 ? (
         <ChessboardSection
           anchor={getAnchor(relatedContentSubmenuTitle)}


### PR DESCRIPTION
### Notes
- The articles which were displaying empty slider don't have any media attached to them
<img width="1128" alt="Screenshot 2025-04-30 at 12 23 17" src="https://github.com/user-attachments/assets/ec4d19c6-1dc1-4e09-9784-55728799f7c1" />

- We now display the slider only if an array of slides is received

### Screenshots
<img width="1340" alt="Screenshot 2025-04-30 at 12 18 44" src="https://github.com/user-attachments/assets/a9f47f63-a5be-4bb2-86a7-18f95a297f70" />
