### PR TITLE
#410 Add aria-label to partner link

### DIFF
--- a/next/src/components/molecules/sections/PartnersSection.tsx
+++ b/next/src/components/molecules/sections/PartnersSection.tsx
@@ -18,6 +18,7 @@ const PartnersSection = ({ partners, title, anchor }: PartnersSectionProps) => {
           <Link
             href={partner.attributes.link ?? '#'}
             key={partner.id}
+            aria-label={partner.attributes.title}
             preserveStyle
             noUnderline
             className="flex items-center justify-center overflow-hidden dh-[115] dw-[115]"


### PR DESCRIPTION
### Description
- Add aria-labels to partner links


### Notes
- We should ensure that partners' titles are always meaningful (content issue)

### Screenshots

<img width="885" alt="Screenshot 2025-05-22 at 13 26 32" src="https://github.com/user-attachments/assets/32d0e852-937b-4327-92e9-39f4abd50168" />

<img width="1342" alt="Screenshot 2025-05-22 at 13 25 14" src="https://github.com/user-attachments/assets/b6bdbda8-1eab-4b8d-b44e-208b95d0e17d" />
