### PR TITLE
#412 Add h1 to main pages and homepage

### DIFF
--- a/next/src/components/pages/HomePage.tsx
+++ b/next/src/components/pages/HomePage.tsx
@@ -39,6 +39,7 @@ const HomePage = ({ page: pageResponse, title, newsItems }: HomePageProps) => {
   return (
     <PageWrapper>
       <SeoHead title={title} seo={page?.seo} />
+      <h1 className="sr-only">{t('common.bratislavaCityGallery')}</h1>
 
       <HighlightsSection
         highlights={page?.highlights

--- a/next/src/components/pages/MainPage.tsx
+++ b/next/src/components/pages/MainPage.tsx
@@ -86,6 +86,7 @@ const MainPage = ({
   return (
     <PageWrapper page={hasAttributes(pageEntity) ? pageEntity : undefined}>
       <SeoHead title={title} seo={page?.seo} />
+      <h1 className="sr-only">{title}</h1>
 
       {page?.sections ? <Submenu items={submenu} /> : null}
 


### PR DESCRIPTION
### Description
- Add h1 to main pages and homepage

### Screenshots
<img width="1179" alt="Screenshot 2025-05-22 at 16 37 10" src="https://github.com/user-attachments/assets/63c27801-1134-4342-9ce4-83b94e8edac0" />

<img width="1192" alt="Screenshot 2025-05-22 at 16 37 31" src="https://github.com/user-attachments/assets/e6c2f992-a4f7-4b7d-9aff-d7476858983d" />
