### PR TITLE
#420 Add aria-label for close button in image gallery

### DIFF
--- a/next/public/locales/en/translation.json
+++ b/next/public/locales/en/translation.json
@@ -51,6 +51,7 @@
   "fileItem.aria.downloadFile": "Download file",
   "fileItem.aria.downloadFileAriaLabel": "Download file {{title}}, format {{format}}, {{size}}",
   "footer.disclosureOfInformation": "Disclosure of information",
+  "galleryModal.aria.closeGallery": "Close image gallery",
   "localization.aria.english": "English",
   "localization.aria.slovak": "Slovensky",
   "map.bikeText": "Leave your bicycle at any of the bike stands or use bike sharing.",

--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -55,6 +55,7 @@
   "fileItem.aria.downloadFile": "Stiahnuť súbor",
   "fileItem.aria.downloadFileAriaLabel": "Stiahnuť súbor {{title}}, formát {{format}}, {{size}}",
   "footer.disclosureOfInformation": "Zverejňovanie informácií",
+  "galleryModal.aria.closeGallery": "Zavrieť galériu obrázkov",
   "localization.aria.english": "English",
   "localization.aria.slovak": "Slovensky",
   "map.bikeText": "Odložte si svoj bicykel v niektorom zo stojanov alebo využite zdieľané bicykle.",

--- a/next/src/components/molecules/ImageGallery.tsx
+++ b/next/src/components/molecules/ImageGallery.tsx
@@ -114,8 +114,13 @@ const ImageGallery = ({ medias = [], className }: ImageGalleryProps) => {
         overlayClassName="bg-[rgba(0,0,0,0.9)] fixed inset-0 z-[51]"
       >
         <div className="relative flex h-full flex-col place-content-center text-white">
-          <button type="button" className="absolute right-xSm top-ySm z-10" onClick={closeModal}>
-            <CloseIcon className="dw-[25]" />
+          <button
+            type="button"
+            className="absolute right-xSm top-ySm z-10"
+            onClick={closeModal}
+            aria-label={t('galleryModal.aria.closeGallery')}
+          >
+            <CloseIcon className="dw-[25]" aria-hidden />
           </button>
           <div>
             <ReactImageGallery


### PR DESCRIPTION
### Description
- Add `aria-label` for close button in image gallery
- The `aria-label` is based on OLO and Bratislava.sk

This issue was found a during recent A11Y audit