### PR TITLE
Remove meilisearch-secret from strapi deployment

### DIFF
--- a/strapi/kubernetes/base/deployment.yml
+++ b/strapi/kubernetes/base/deployment.yml
@@ -34,8 +34,6 @@ spec:
             - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-database-secret
             - secretRef:
-                name: ${BUILD_REPOSITORY_NAME}-meilisearch-secret
-            - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-internals-secret
             - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-minio-secret


### PR DESCRIPTION
meilisearch-secret should only be mounted in stateful-set-meilisearch.yml (the Meilisearch pod itself). It was incorrectly added to deployment.yml (the Strapi app pod).