### PR TITLE
chore: pin remaining ranged version to lockfile

### DIFF
--- a/strapi/package.json
+++ b/strapi/package.json
@@ -14,7 +14,7 @@
     "postinstall": "patch-package"
   },
   "devDependencies": {
-    "cross-env": "^7.0.3"
+    "cross-env": "7.0.3"
   },
   "dependencies": {
     "@strapi/plugin-graphql": "4.26.0",


### PR DESCRIPTION
## Summary
- Replace `^7.0.3` with `7.0.3` for `cross-env` in `strapi/package.json` to match `package-lock.json`.
- `next/package.json` already fully pinned.

## Test plan
- [ ] CI green